### PR TITLE
Fix the stripping of file lists from Git messages.

### DIFF
--- a/src/repo/ShipItRepoGIT.php
+++ b/src/repo/ShipItRepoGIT.php
@@ -91,17 +91,15 @@ class ShipItRepoGIT
 
     $message = trim($message);
 
-    $matches = [];
-    preg_match(
-      "/^((.*\\n)?)---\\n /us",
-      $message,
-      $matches,
-      PREG_OFFSET_CAPTURE
-    );
-    if (count($matches) > 0) {
-      // get rid of file list
-      $length = strlen($matches[1][0]);
-      $message = trim(substr($message, 0, $length));
+    $start_of_filelist = strrpos($message, "\n---\n ");
+    if ($start_of_filelist !== false) {
+      // Get rid of the file list when a summary is
+      // included in the commit message
+      $message = trim(substr($message, 0, $start_of_filelist));
+    } else if (strpos($message, "---\n ") === 0) {
+      // Git rid of the file list in the situation where there is
+      // no summary in the commit message (when it starts with "---\n").
+      $message = '';
     }
 
     $changeset = (new ShipItChangeset())->withMessage($message);


### PR DESCRIPTION
Currently, the stripping of the file list from Git messages only works for messages that include a summary. For instance:

```
This is my Git message title.

Some summary for my git commit.

--
 [ file list here ]
```

However, when syncing commits that only have a single line, and have no commit message, the file list is included because it can't find a new line prior to the "---".

This commit replaces this functionality to include a regex that looks at the beginning of the message, and then does a substr to determine the commit message.