### PR TITLE
Make ShipItCreateNewRepoPhase respect destination branch option.

### DIFF
--- a/src/phase/ShipItCreateNewRepoPhase.php
+++ b/src/phase/ShipItCreateNewRepoPhase.php
@@ -148,7 +148,7 @@ final class ShipItCreateNewRepoPhase extends ShipItPhase {
     $filtered_repo = ShipItRepo::typedOpen(
       ShipItDestinationRepo::class,
       $filtered_dir->getPath(),
-      '--orphan=master',
+      '--orphan='.$config->getDestinationBranch(),
     );
     $filtered_repo->commitPatch($changeset);
 


### PR DESCRIPTION
Rather than create a new repo with a "master" orphan branch, create the new repo with an orphan branch of whatever was specified in "--destination-branch".