### PR TITLE
Fix Git `export`.

### DIFF
--- a/src/repo/ShipItRepoGIT.php
+++ b/src/repo/ShipItRepoGIT.php
@@ -327,7 +327,7 @@ class ShipItRepoGIT
       $dest->getPath(),
       'tar',
       'x',
-    ))->runSynchronously();
+    ))->setStdIn($tar)->runSynchronously();
 
     return shape('tempDir' => $dest, 'revision' => $rev);
   }


### PR DESCRIPTION
Currently creating an initial repo with Git doesn't work. It hangs, because the output of the `git archive` command is never piped into the `tar x` command.