### PR TITLE
Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.
+
 ## Pull Requests
 We actively welcome your pull requests.
 


### PR DESCRIPTION
**What is the change?**

Adding a document linking to the Facebook Open Source Code of Conduct,
for visibility and to meet GitHub community standards.

**Why make this change?**

Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by GitHub via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

**Issue**

Internal task t23481323
