### PR TITLE
Update travis.yml to build only on nightly and latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 env:
   matrix:
-   - HHVM_VERSION=3.24-lts-latest
+   - HHVM_VERSION=3.26.3
    - HHVM_VERSION=latest
 install:
  - docker pull hhvm/hhvm:$HHVM_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 env:
   matrix:
-   - HHVM_VERSION=3.26.3
+   - HHVM_VERSION=nightly
    - HHVM_VERSION=latest
 install:
  - docker pull hhvm/hhvm:$HHVM_VERSION


### PR DESCRIPTION
Summary:
The Travis build has been failing for 1.5 months due to a breaking change with a new Hack language feature (<<__OptionalDestruct>>). Rather than trying to continue supporting the LTS Hack version (3.24), it's easier to just bump up the minimum supported version.

Test Plan: Travis CI