### PR TITLE
Don't strip the summary if `@already-on-github` is present

### DIFF
--- a/fb-examples/lib/shipit/FBCommonFilters.php-example
+++ b/fb-examples/lib/shipit/FBCommonFilters.php-example
@@ -49,11 +49,16 @@ final class FBCommonFilters {
   public static function stripSummariesByDefault(
     ShipItChangeset $changeset,
   ): ShipItChangeset {
-    if (ShipItMentions::containsMention($changeset, '@public')) {
+    $mentions = ShipItMentions::getMentions($changeset);
+    if ($mentions->contains('@public')) {
       return ShipItMentions::rewriteMentions(
         $changeset,
         $mention ==> $mention === '@public' ? '' : $mention,
       );
+    }
+
+    if ($mentions->contains('@already-on-github')) {
+      return $changeset;
     }
 
     $sections = ShipItMessageSections::getSections(


### PR DESCRIPTION
Stripping the summary first will result in not being able to use the `@already-on-github` pragma to skip syncing the commit.

Original diff: D10048136