### PR TITLE
add fai-pep config into opensource ShipIt

### DIFF
--- a/fb-examples/config/facebook/FAI-PEP.php-example
+++ b/fb-examples/config/facebook/FAI-PEP.php-example
@@ -1,0 +1,33 @@
+<?hh // strict
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\ShipIt\Config;
+
+use type Facebook\ShipIt\ {
+  FBShipItCLIStaticConfig,
+  FBShipItConfig,
+};
+
+final class FacebookFaiPep extends FBShipItConfig {
+  const string ROOT = 'xplat/aibench/oss/';
+
+  <<__Override>>
+  public static function getDefaultPathMappings(): ImmMap<string, string> {
+    return ImmMap {
+      self::ROOT => '',
+    };
+  }
+
+  <<__Override>>
+  public static function getStaticConfig(): FBShipItCLIStaticConfig {
+    return shape(
+      'internalRepo' => 'fbsource',
+      'githubOrg' => 'facebook',
+      'githubProject' => 'FAI-PEP',
+    );
+  }
+}

--- a/fb-examples/tests/config/FacebookFaiPepTest.php-example
+++ b/fb-examples/tests/config/FacebookFaiPepTest.php-example
@@ -1,0 +1,19 @@
+<?hh // strict
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+namespace Facebook\ShipIt\Config;
+
+final class FacebookFaiPepTest extends FBConfigBaseTest {
+  <<__Override>>
+  public static function getExamplePathMappings(): ImmMap<string, ?string> {
+    return ImmMap {
+      'xplat/aibench/oss/README.md' => 'README.md',
+      'xplat/aibench/oss/benchmarking/CONTRIBUTING.md' =>
+        'benchmarking/CONTRIBUTING.md',
+    };
+  }
+}


### PR DESCRIPTION
Summary:
We want to merge our oss github project fai-pep with our internal fbsource/xplat/aibench. The plan is oss facebook/fai-pep will be sync with internal fbsource/xplat/aibench/oss

This diff just add two files from oss project. If everything works correctly, I will merge all files in an later diff.

Differential Revision: D13640791
