### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -3,7 +3,7 @@ set -ex
 
 add-apt-repository ppa:git-core/ppa
 UBUNTU_VERSION=$(lsb_release -r -s)
-if (( $(echo "$UBUNTU_VERSION < 18.0" | bc -l) )); then
+if [ ${UBUNTU_VERSION:0:2} -lt "18" ]; then
   add-apt-repository ppa:mercurial-ppa/releases
 fi
 apt-get update

--- a/.travis.sh
+++ b/.travis.sh
@@ -2,6 +2,10 @@
 set -ex
 
 add-apt-repository ppa:git-core/ppa
+UBUNTU_VERSION=$(lsb_release -r -s)
+if (( $(echo "$UBUNTU_VERSION < 18.0" | bc -l) )); then
+  add-apt-repository ppa:mercurial-ppa/releases
+fi
 apt-get update
 apt-get install -y \
   git \

--- a/.travis.sh
+++ b/.travis.sh
@@ -2,8 +2,9 @@
 set -ex
 
 add-apt-repository ppa:git-core/ppa
+# Must use a newer hg version than default on Xenial and lower
 UBUNTU_VERSION=$(lsb_release -r -s)
-if [ ${UBUNTU_VERSION:0:2} -lt "18" ]; then
+if [ $(echo $UBUNTU_VERSION | cut -c1-2) -lt "18" ]; then
   add-apt-repository ppa:mercurial-ppa/releases
 fi
 apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
  - docker
 env:
   matrix:
-   - HHVM_VERSION=nightly
    - HHVM_VERSION=latest
    - HHVM_VERSION=3.30-lts-latest
 install:

--- a/tests/shipit/github/expect.php
+++ b/tests/shipit/github/expect.php
@@ -27,11 +27,15 @@ class ShimExpectObj<T> extends Facebook\FBExpect\ExpectObj<T> {
   }
 
   public function toMatchRegex(string $expected, string $msg = '', ...): void {
+    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $msg = \vsprintf($msg, \array_slice(\func_get_args(), 2));
     $this->assertRegExp($expected, (string) $this->varShim, $msg);
   }
 
   public function toNotMatchRegex(string $expected, string $msg = '', ...): void {
+    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $msg = \vsprintf($msg, \array_slice(\func_get_args(), 2));
     $this->assertNotRegExp($expected, (string) $this->varShim, $msg);
   }

--- a/tests/shipit/github/expect.php
+++ b/tests/shipit/github/expect.php
@@ -26,17 +26,13 @@ class ShimExpectObj<T> extends Facebook\FBExpect\ExpectObj<T> {
     $this->toNotContain($needle, $msg);
   }
 
-  public function toMatchRegex(string $expected, string $msg = '', ...): void {
-    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-    $msg = \vsprintf($msg, \array_slice(\func_get_args(), 2));
+  public function toMatchRegex(string $expected, string $msg = '', mixed ...$args): void {
+    $msg = \vsprintf($msg, $args);
     $this->assertRegExp($expected, (string) $this->varShim, $msg);
   }
 
-  public function toNotMatchRegex(string $expected, string $msg = '', ...): void {
-    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-    $msg = \vsprintf($msg, \array_slice(\func_get_args(), 2));
+  public function toNotMatchRegex(string $expected, string $msg = '', mixed ...$args): void {
+    $msg = \vsprintf($msg, $args);
     $this->assertNotRegExp($expected, (string) $this->varShim, $msg);
   }
 }


### PR DESCRIPTION
- Use the Mercurial PPA for Ubuntu Xenial and older
- Can't use the Mercurial PPA for Ubuntu Bionic and newer
- Fix HHVM 4.1 type errors in expect.php
- Remove HHVM nightly, because it's incompatible with the latest published dependencies