### PR TITLE
Fix regex detecting fbshipit-source-id in ShipItRepoGIT

### DIFF
--- a/src/shipit/repo/ShipItRepoGIT.php
+++ b/src/shipit/repo/ShipItRepoGIT.php
@@ -79,7 +79,7 @@ class ShipItRepoGIT
   ): ?string {
     $log = $this->gitCommand(
       'log', '-1', '--grep',
-      '^\\(fb\\)\\?shipit-source-id: [a-z0-9]\\+$',
+      '^\\(fb\\)\\?shipit-source-id: \\?[a-z0-9]\\+\\s*$',
       ...$roots,
     );
     $log = Str\trim($log);
@@ -87,8 +87,8 @@ class ShipItRepoGIT
     if (
       /* HH_IGNORE_ERROR[2049] __PHPStdLib */
       /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-      !\preg_match(
-        '/^ *(fb)?shipit-source-id: (?<commit>[a-z0-9]+)$/m',
+      !\preg_match_all(
+        '/^ *(fb)?shipit-source-id: ?(?<commit>[a-z0-9]+)$/m',
         $log,
         &$matches,
       )
@@ -103,7 +103,10 @@ class ShipItRepoGIT
     if (!\array_key_exists('commit', $matches)) {
       return null;
     }
-    return $matches['commit'];
+    if (!\is_array($matches['commit'])) {
+      return null;
+    }
+    return C\last($matches['commit']);
   }
 
   public function findNextCommit(

--- a/src/shipit/repo/ShipItRepoHG.php
+++ b/src/shipit/repo/ShipItRepoHG.php
@@ -118,7 +118,7 @@ class ShipItRepoHG extends ShipItRepo
       '--limit',
       '1',
       '--keyword',
-      'fbshipit-source-id: ',
+      'fbshipit-source-id:',
       '--template',
       '{desc}',
       ...$roots,
@@ -129,7 +129,7 @@ class ShipItRepoHG extends ShipItRepo
       /* HH_IGNORE_ERROR[2049] __PHPStdLib */
       /* HH_IGNORE_ERROR[4107] __PHPStdLib */
       !\preg_match_all(
-        '/^ *fbshipit-source-id: (?<commit>[a-z0-9]+)$/m',
+        '/^ *fbshipit-source-id: ?(?<commit>[a-z0-9]+)$/m',
         $log,
         &$matches,
       )

--- a/tests/shipit/BaseTest.php
+++ b/tests/shipit/BaseTest.php
@@ -14,6 +14,20 @@ namespace Facebook\ShipIt;
 
 abstract class BaseTest extends \Facebook\HackTest\HackTest { // @oss-enable
 // @oss-disable: abstract class BaseTest extends \HackTest {
+
+  public async function setUp(): Awaitable<void> {} // @oss-enable
+  public async function tearDown(): Awaitable<void> {} // @oss-enable
+
+  <<__Override>> // @oss-enable
+  public async function beforeEachTestAsync(): Awaitable<void> { // @oss-enable
+    await $this->setUp(); // @oss-enable
+  } // @oss-enable
+
+  <<__Override>> // @oss-enable
+  public async function afterEachTestAsync(): Awaitable<void> { // @oss-enable
+    await $this->tearDown(); // @oss-enable
+  } // @oss-enable
+
   protected static function diffsFromMap(
     ImmMap<string, string> $diffs,
   ): ImmVector<ShipItDiff> {

--- a/tests/shipit/UnicodeTest.php
+++ b/tests/shipit/UnicodeTest.php
@@ -22,8 +22,7 @@ final class UnicodeTest extends BaseTest {
   private ?string $ctype;
 
   <<__Override>>
-  // @oss-disable: public async function setUp(): Awaitable<void> {
-    public async function beforeEachTestAsync(): Awaitable<void> { // @oss-enable
+  public async function setUp(): Awaitable<void> {
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $ctype = \getenv('LC_CTYPE');
@@ -36,8 +35,7 @@ final class UnicodeTest extends BaseTest {
   }
 
   <<__Override>>
-  // @oss-disable: public async function tearDown(): Awaitable<void> {
-    public async function afterEachTestAsync(): Awaitable<void> { // @oss-enable
+  public async function tearDown(): Awaitable<void> {
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     \putenv('LC_CTYPE='.$this->ctype);


### PR DESCRIPTION
Summary: This regex was skipping this commit, because of whitespace: https://github.com/facebook/fbshipit/commit/c9708a3da39e24d4dfb6524166abec97de38fd33

Reviewed By: cdelahousse

Differential Revision: D14886823
