### PR TITLE
Fix Travis build for HHVM:latest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
   "license": [ "MIT" ],
   "require": {
     "hhvm": "~3.30 | ~4.0",
-    "hhvm/hsl": "~3.30.0 | ~4.0.0",
-    "hhvm/hsl-experimental": "~3.30.4 | ~4.0.0",
+    "hhvm/hsl": "~3.30.0 | ~4.0",
+    "hhvm/hsl-experimental": "~3.30.4 | ~4.0",
     "hhvm/hhvm-autoload": "~1.8 | ~2.0",
-    "facebook/hh-clilib": "~2.0.1 | ~2.1.1"
+    "facebook/hh-clilib": "~2.0.1 | ~2.1"
   },
   "require-dev": {
     "hhvm/hacktest": "~1.3 | ~1.4",
-    "facebook/fbexpect": "~2.3.1 | ~2.5.6"
+    "facebook/fbexpect": "~2.3.1 | ~2.5"
   },
   "autoload": {
     "classmap": [


### PR DESCRIPTION
The 4.0.X versions of HSL aren't compatible with HHVM 4.1.X.