### PR TITLE
Re-sync with internal repository

### DIFF
--- a/fb-examples/lib/shipit/FBCommonFilters.php-example
+++ b/fb-examples/lib/shipit/FBCommonFilters.php-example
@@ -439,7 +439,7 @@ final class FBCommonFilters {
         async $name ==>
           await FBToGitHubUserInfo::getDestinationUserFromLocalUser($name),
       );
-    // @oss-disable: $names = \Asio::awaitSynchronously(\vAsync($names))
+    // @oss-disable: $names = \Asio::awaitSynchronously(\genv($names))
       $names = \HH\Asio\join(\HH\Asio\v($names)) // @oss-enable
       ->filter($x ==> Str\length($x ?? '') > 0);
     $names = Vec\filter_nulls($names);


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.