### PR TITLE
remove lies_we_tell_hack.hhi from HSL (#98)

### DIFF
--- a/fb-examples/lib/shipit/FBShipItPreview.php-example
+++ b/fb-examples/lib/shipit/FBShipItPreview.php-example
@@ -55,7 +55,7 @@ final class FBShipItPreview {
     try {
       $repo = RepoArcanistProject::getRepo($arcanist_project);
     // @oss-disable: } catch (\InvariantViolationException $_e) {
-      } catch (\HH\InvariantException $e) { // @oss-enable
+      } catch (InvariantException $e) { // @oss-enable
       // If we don't recognize the arcanist project,
       // assume it will ship no commits.
       return vec[];

--- a/fb-examples/tests/shipit/FBCommonFiltersTest.php-example
+++ b/fb-examples/tests/shipit/FBCommonFiltersTest.php-example
@@ -390,7 +390,7 @@ Name2';
       FBCommonFilters::applyAll($changeset_1);
     })
       // @oss-disable: ->toThrow(\InvariantViolationException::class);
-    ->toThrow(\HH\InvariantException::class); // @oss-enable
+    ->toThrow(InvariantException::class); // @oss-enable
     $changeset_2 = (new ShipItChangeset())
       ->withMessage($original_message);
     $changeset_2 = FBCommonFilters::applyAll($changeset_2);

--- a/fb-examples/tests/shipit/FBProjectBaseTest.php-example
+++ b/fb-examples/tests/shipit/FBProjectBaseTest.php-example
@@ -269,7 +269,7 @@ abstract class FBProjectBaseTest extends FBBaseTest {
       static::map($changeset);
     })
       // @oss-disable: ->toThrow(\InvariantViolationException::class);
-    ->toThrow(\HH\InvariantException::class); // @oss-enable
+    ->toThrow(InvariantException::class); // @oss-enable
   }
 
   public function testBadwordsBinaryFile(): void {

--- a/fb-examples/tests/shipit/FBShipItProjectRunnerTest.php-example
+++ b/fb-examples/tests/shipit/FBShipItProjectRunnerTest.php-example
@@ -93,7 +93,7 @@ final class FBShipItProjectRunnerTest extends FBBaseTest {
     \expect($phase)->toBeInstanceOf(FBImportItBranchResolutionPhase::class);
     \expect(() ==> $phase->getBranchConfigs())
       // @oss-disable: ->toThrow(\InvariantViolationException::class);
-    ->toThrow(\HH\InvariantException::class); // @oss-enable
+    ->toThrow(InvariantException::class); // @oss-enable
   }
 
   private static function getConfigObject(): FBShipItConfig {

--- a/tests/shipit/FilterSanityCheckPhaseTest.php
+++ b/tests/shipit/FilterSanityCheckPhaseTest.php
@@ -57,7 +57,7 @@ final class FilterSanityCheckPhaseTest extends BaseTest {
       $phase->assertValid(keyset['foo/']);
     })
       // @oss-disable: ->toThrow(\InvariantViolationException::class);
-    ->toThrow(\HH\InvariantException::class); // @oss-enable
+    ->toThrow(InvariantException::class); // @oss-enable
   }
 
   public function testThrowsForEmptyChangeset(): void {
@@ -68,7 +68,7 @@ final class FilterSanityCheckPhaseTest extends BaseTest {
       $phase->assertValid(keyset['foo/']);
     })
       // @oss-disable: ->toThrow(\InvariantViolationException::class);
-    ->toThrow(\HH\InvariantException::class); // @oss-enable
+    ->toThrow(InvariantException::class); // @oss-enable
   }
 
   public function testThrowsForPartialMatch(): void {
@@ -84,6 +84,6 @@ final class FilterSanityCheckPhaseTest extends BaseTest {
       $phase->assertValid(keyset['foo/', 'herp/']);
     })
       // @oss-disable: ->toThrow(\InvariantViolationException::class);
-    ->toThrow(\HH\InvariantException::class); // @oss-enable
+    ->toThrow(InvariantException::class); // @oss-enable
   }
 }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/hhvm/hsl/pull/98

In HSL and open-source projects that depend on it, most of these "lies" are unneeded, and the remaining places that depend on them can be avoided by changing `\HH\InvariantException` to `InvariantException`. Without namespace, it will always be correctly resolved to wherever HHVM autoimports it from.

"wherever HHVM autoimports it from" is actually changing (it used to be `\InvariantException` but is `\HH\InvariantException` as of a few days ago), which is the reason why this file is problematic. Before the HHVM change, and without the diff, the file was needed -- but after the HHVM change, the file causes Hack errors in HSL and [anything that depends on it](https://travis-ci.org/hhvm/)).

Reviewed By: fredemmott

Differential Revision: D18121499

