### PR TITLE
Prevent HH_IGNORE_ERROR from consuming all

### DIFF
--- a/fb-examples/lib/config/FBShipItConfig.php-example
+++ b/fb-examples/lib/config/FBShipItConfig.php-example
@@ -202,9 +202,7 @@ abstract class FBShipItConfig {
       // already computed, we do not need to add this as it would be redundant.
       $root_match = false;
       foreach ($roots as $root) {
-        /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-        /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        $root_match = $root_match || \strncmp($path, $root, Str\length($root)) === 0;
+        $root_match = $root_match || Str\starts_with($path, $root);
       }
       if ($root_match) {
         continue;

--- a/fb-examples/lib/config/FBWWWBasePlugin.php-example
+++ b/fb-examples/lib/config/FBWWWBasePlugin.php-example
@@ -75,9 +75,7 @@ abstract class FBWWWBasePlugin extends FBShipItConfigeratorConfig {
     $diffs = vec[];
     foreach ($changeset->getDiffs() as $diff) {
       $diff['body'] = $diff['body']
-        /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-        /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        |> \explode("\n", $$)
+        |> Str\split($$, "\n")
         |> (new ImmVector($$))->map(
           $line ==> {
             $_count = null;

--- a/fb-examples/lib/config/FBWWWBasePlugin.php-example
+++ b/fb-examples/lib/config/FBWWWBasePlugin.php-example
@@ -76,7 +76,8 @@ abstract class FBWWWBasePlugin extends FBShipItConfigeratorConfig {
     foreach ($changeset->getDiffs() as $diff) {
       $diff['body'] = $diff['body']
         |> Str\split($$, "\n")
-        |> (new ImmVector($$))->map(
+        |> Vec\map(
+          $$,
           $line ==> {
             $_count = null;
             /* HH_IGNORE_ERROR[2049] __PHPStdLib */

--- a/fb-examples/lib/shipit/FBCommonFilters.php-example
+++ b/fb-examples/lib/shipit/FBCommonFilters.php-example
@@ -421,7 +421,7 @@ final class FBCommonFilters {
         self::getSupportedMessageSectionNames(),
       );
       if (C\contains_key($sections, 'reviewed by')) {
-        $names = (new Vector(Str\split($sections['reviewed by'], ', ')));
+        $names = Str\split($sections['reviewed by'], ', ');
         if (C\count($names) === 1) {
           $pulled_by_unixname = $names[0];
         }
@@ -454,10 +454,11 @@ final class FBCommonFilters {
     if (!C\contains_key($sections, 'reviewed by')) {
       return $changeset;
     }
-    $names = (new Vector(Str\split($sections['reviewed by'], ', ')))
+    $names = Str\split($sections['reviewed by'], ', ')
       // No project reviewers e.g., #WDT in D2407623
-      ->filter($name ==> Str\slice(Str\trim($name), 0, 1) !== '#')
-      ->map(
+      |> Vec\filter($$, $name ==> Str\slice(Str\trim($name), 0, 1) !== '#')
+      |> Vec\map_async(
+        $$,
         async $name ==>
           await FBToGitHubUserInfo::getDestinationUserFromLocalUser($name),
       );

--- a/fb-examples/lib/shipit/FBShipItProjectRunner.php-example
+++ b/fb-examples/lib/shipit/FBShipItProjectRunner.php-example
@@ -196,9 +196,7 @@ final class FBShipItProjectRunner extends ShipItPhaseRunner {
       $this->parseOptions($project_config, self::getRawOpts($project_config));
     }
     if (
-      /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-      /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-      \array_key_exists('h', $raw_opts) || \array_key_exists('help', $raw_opts)
+      C\contains_key($raw_opts, 'h') || C\contains_key($raw_opts, 'help')
     ) {
       // hacky coupling with FBShipItBranchResolutionPhase
       // render the project's help message

--- a/fb-examples/tests/shipit/FBProjectBaseTest.php-example
+++ b/fb-examples/tests/shipit/FBProjectBaseTest.php-example
@@ -346,9 +346,7 @@ abstract class FBProjectBaseTest extends FBBaseTest {
     foreach ($shipit_class::getPathMappings() as $source_path => $_) {
       $found = false;
       foreach ($examples as $example) {
-        /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-        /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        if (\strncmp($example, $source_path, Str\length($source_path)) === 0) {
+        if (C\starts_with($example, $source_path)) {
           $found = true;
           break;
         }

--- a/src/importit/filter/ImportItSubmoduleFilter.php
+++ b/src/importit/filter/ImportItSubmoduleFilter.php
@@ -88,9 +88,7 @@ final class ImportItSubmoduleFilter {
 
       $new_rev = null;
       $old_rev = null;
-      /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-      /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-      foreach (\explode("\n", $body) as $line) {
+      foreach (Str\split($body, "\n") as $line) {
         /* HH_IGNORE_ERROR[2049] __PHPStdLib */
         /* HH_IGNORE_ERROR[4107] __PHPStdLib */
         if (!\strncmp('-Subproject commit ', $line, 19)) {

--- a/src/importit/filter/ImportItSubmoduleFilter.php
+++ b/src/importit/filter/ImportItSubmoduleFilter.php
@@ -89,13 +89,9 @@ final class ImportItSubmoduleFilter {
       $new_rev = null;
       $old_rev = null;
       foreach (Str\split($body, "\n") as $line) {
-        /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-        /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        if (!\strncmp('-Subproject commit ', $line, 19)) {
+        if (Str\starts_with($line, '-Subproject commit ')) {
           $old_rev = Str\trim(Str\slice($line, 19));
-          /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-          /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        } else if (!\strncmp('+Subproject commit ', $line, 19)) {
+        } else if (Str\starts_with($line, '+Subproject commit ')) {
           $new_rev = Str\trim(Str\slice($line, 19));
         }
       }

--- a/src/shipit/ShipItShellCommand.php
+++ b/src/shipit/ShipItShellCommand.php
@@ -116,7 +116,7 @@ final class ShipItShellCommand {
       unset($fds[0]);
     }
     /* HH_FIXME[2050] undefined $_ENV */
-    $env_vars = (new Map($_ENV))->setAll($this->environmentVariables);
+    $env_vars = Dict\merge($_ENV, $this->environmentVariables);
 
     $command = $this->getCommandAsString();
     $pipes = varray[];

--- a/src/shipit/filter/ShipItConditionalLinesFilter.php
+++ b/src/shipit/filter/ShipItConditionalLinesFilter.php
@@ -13,7 +13,7 @@
 
 namespace Facebook\ShipIt;
 
-use namespace HH\Lib\Str;
+use namespace HH\Lib\{Str, Vec};
 
 /**
  * Comments or uncomments specially marked lines.
@@ -96,8 +96,9 @@ final class ShipItConditionalLinesFilter {
   ): ShipItChangeset {
     $diffs = vec[];
     foreach ($changeset->getDiffs() as $diff) {
-      $diff['body'] = (new ImmVector(Str\split($diff['body'], "\n")))
-        ->map(
+      $diff['body'] = Str\split($diff['body'], "\n")
+        |> Vec\map(
+          $$,
           /* HH_IGNORE_ERROR[2049] __PHPStdLib */
           /* HH_IGNORE_ERROR[4107] __PHPStdLib */
           $line ==> \preg_replace($pattern, $replacement, $line, /* limit */ 1),

--- a/src/shipit/filter/ShipItConditionalLinesFilter.php
+++ b/src/shipit/filter/ShipItConditionalLinesFilter.php
@@ -96,9 +96,7 @@ final class ShipItConditionalLinesFilter {
   ): ShipItChangeset {
     $diffs = vec[];
     foreach ($changeset->getDiffs() as $diff) {
-      /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-      /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-      $diff['body'] = (new ImmVector(\explode("\n", $diff['body'])))
+      $diff['body'] = (new ImmVector(Str\split($diff['body'], "\n")))
         ->map(
           /* HH_IGNORE_ERROR[2049] __PHPStdLib */
           /* HH_IGNORE_ERROR[4107] __PHPStdLib */

--- a/src/shipit/filter/ShipItMessageSections.php
+++ b/src/shipit/filter/ShipItMessageSections.php
@@ -37,9 +37,7 @@ final class ShipItMessageSections {
   ): dict<string, string> {
     $sections = dict['' => ''];
     $section = '';
-    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-    foreach (\explode("\n", $changeset->getMessage()) as $line) {
+    foreach (Str\split($changeset->getMessage(), "\n") as $line) {
       $line = Str\trim_right($line);
       /* HH_IGNORE_ERROR[2049] __PHPStdLib */
       /* HH_IGNORE_ERROR[4107] __PHPStdLib */
@@ -101,9 +99,7 @@ final class ShipItMessageSections {
   }
 
   private static function hasMoreThanOneNonEmptyLine(string $str): bool {
-    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-    $lines = \explode("\n", $str);
+    $lines = Str\split($str, "\n");
     $cn = 0;
     foreach ($lines as $line) {
       /* HH_IGNORE_ERROR[2049] __PHPStdLib */

--- a/src/shipit/filter/ShipItPathFilters.php
+++ b/src/shipit/filter/ShipItPathFilters.php
@@ -84,9 +84,7 @@ abstract final class ShipItPathFilters {
           return $path;
         }
         foreach ($mapping as $src => $dest) {
-          /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-          /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-          if (\strncmp($path, $src, Str\length($src)) !== 0) {
+          if (!Str\starts_with($path, $src)) {
             continue;
           }
           return $dest.Str\slice($path, Str\length($src));

--- a/src/shipit/filter/ShipItSubmoduleFilter.php
+++ b/src/shipit/filter/ShipItSubmoduleFilter.php
@@ -93,13 +93,9 @@ index %s..0000000
       $new_rev = null;
       $old_rev = null;
       foreach (Str\split($body, "\n") as $line) {
-        /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-        /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        if (!\strncmp('-Subproject commit ', $line, 19)) {
+        if (Str\starts_with($line, '-Subproject commit ')) {
           $old_rev = Str\trim(Str\slice($line, 19));
-          /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-          /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        } else if (!\strncmp('+Subproject commit ', $line, 19)) {
+        } else if (Str\starts_with($line, '+Subproject commit ')) {
           $new_rev = Str\trim(Str\slice($line, 19));
         }
       }

--- a/src/shipit/filter/ShipItSubmoduleFilter.php
+++ b/src/shipit/filter/ShipItSubmoduleFilter.php
@@ -92,9 +92,7 @@ index %s..0000000
 
       $new_rev = null;
       $old_rev = null;
-      /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-      /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-      foreach (\explode("\n", $body) as $line) {
+      foreach (Str\split($body, "\n") as $line) {
         /* HH_IGNORE_ERROR[2049] __PHPStdLib */
         /* HH_IGNORE_ERROR[4107] __PHPStdLib */
         if (!\strncmp('-Subproject commit ', $line, 19)) {

--- a/src/shipit/filter/ShipItUserFilters.php
+++ b/src/shipit/filter/ShipItUserFilters.php
@@ -12,7 +12,7 @@
  */
 namespace Facebook\ShipIt;
 
-use namespace HH\Lib\Str;
+use namespace HH\Lib\{Str, C};
 
 final class ShipItUserFilters {
   /** Rewrite authors that match a certain pattern.
@@ -29,9 +29,7 @@ final class ShipItUserFilters {
       /* HH_IGNORE_ERROR[2049] __PHPStdLib */
       /* HH_IGNORE_ERROR[4107] __PHPStdLib */
       \preg_match_with_matches($pattern, $changeset->getAuthor(), inout $matches) &&
-      /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-      /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-      \array_key_exists('user', $matches)
+      C\contains_key($matches, 'user')
     ) {
       // @oss-disable: $author = \Asio::awaitSynchronously(
         $author = \HH\Asio\join( // @oss-enable

--- a/src/shipit/phase/ShipItPhaseRunner.php
+++ b/src/shipit/phase/ShipItPhaseRunner.php
@@ -291,10 +291,8 @@ class ShipItPhaseRunner {
     $opt_help = Str\join(
       Dict\map(
         $rows,
-        $row ==> /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-      /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-      /* HH_FIXME[4297] Exposed by upgraded typechecker (new_inference) */
-      Str\format("%s  %s\n", \str_pad($row[0], $max_left), $row[1]),
+        $row ==>
+          Str\format("%s  %s\n", Str\pad_right($row[0], $max_left), $row[1]),
       ),
       "",
     );

--- a/src/shipit/phase/ShipItPhaseRunner.php
+++ b/src/shipit/phase/ShipItPhaseRunner.php
@@ -242,14 +242,7 @@ class ShipItPhaseRunner {
       Vec\map($config, $opt ==> $opt['long_name']),
     )
       |> dict($$);
-    if (
-      /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-      /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-      \array_key_exists('h', $raw_opts) ||
-      /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-        /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        \array_key_exists('help', $raw_opts)
-    ) {
+    if (C\contains_key($raw_opts, 'h') || C\contains_key($raw_opts, 'help')) {
       self::printHelp($config);
       exit(0);
     }

--- a/src/shipit/phase/ShipItPhaseRunner.php
+++ b/src/shipit/phase/ShipItPhaseRunner.php
@@ -282,10 +282,10 @@ class ShipItPhaseRunner {
 
       $rows[$long] = tuple($left, $description);
     }
-    $rows = Dict\sort_by_key($rows) |> new Map($$);
+    $rows = Dict\sort_by_key($rows);
 
     $help = $rows['help'];
-    $rows->removeKey('help');
+    unset($rows['help']);
     $rows = Dict\merge(dict['help' => $help], $rows);
 
     $opt_help = Str\join(

--- a/src/shipit/phase/ShipItSyncPhase.php
+++ b/src/shipit/phase/ShipItSyncPhase.php
@@ -67,9 +67,7 @@ final class ShipItSyncPhase extends ShipItPhase {
         'long_name' => 'skip-source-commits::',
         'description' => "Comma-separate list of source commit IDs to skip.",
         'write' => $x ==> {
-          /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-            /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-            $this->skippedSourceCommits = keyset(\explode(',', $x));
+          $this->skippedSourceCommits = keyset(Str\split($x, ','));
           foreach ($this->skippedSourceCommits as $commit) {
             // 7 happens to be the usual output
             if (Str\length($commit) < ShipItUtil::SHORT_REV_LENGTH) {

--- a/src/shipit/repo/ShipItRepoGIT.php
+++ b/src/shipit/repo/ShipItRepoGIT.php
@@ -136,9 +136,7 @@ class ShipItRepoGIT
           $changeset = $changeset->withAuthor($value);
           break;
         case 'subject':
-          /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-          /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-          if (!\strncasecmp($value, '[PATCH] ', 8)) {
+          if (Str\starts_with_ci($value, '[PATCH] ')) {
             $value = Str\trim(Str\slice($value, 8));
           }
           $changeset = $changeset->withSubject($value);

--- a/src/shipit/repo/ShipItRepoGIT.php
+++ b/src/shipit/repo/ShipItRepoGIT.php
@@ -46,8 +46,7 @@ class ShipItRepoGIT
 
   <<__Override>>
   public function updateBranchTo(string $base_rev): void {
-    /* HH_FIXME[4276] truthiness test on string */
-    if (!$this->branch) {
+    if (Str\is_empty($this->branch)) {
       throw new ShipItRepoGITException(
         $this,
         'setBranch must be called first.',

--- a/src/shipit/repo/ShipItRepoHG.php
+++ b/src/shipit/repo/ShipItRepoHG.php
@@ -232,13 +232,9 @@ class ShipItRepoHG
         continue;
       }
       if ($line[0] === '#' && !$past_separator) {
-        /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-        /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        if (!\strncasecmp($line, '# User ', 7)) {
+        if (Str\starts_with_ci($line, '# User ')) {
           $changeset = $changeset->withAuthor(Str\slice($line, 7));
-          /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-          /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-        } else if (!\strncasecmp($line, '# Date ', 7)) {
+        } else if (Str\starts_with_ci($line, '# Date ')) {
           $changeset = $changeset->withTimestamp((int)Str\slice($line, 7));
         }
         // Ignore anything else in the envelope

--- a/src/shipit/repo/ShipItRepoHG.php
+++ b/src/shipit/repo/ShipItRepoHG.php
@@ -362,7 +362,7 @@ class ShipItRepoHG
     // Some server-side commands will inexplicitly fail, and then succeed the
     // next time they are ran.  There are a some, however, that we never want
     // to re-run because we'll lose error messages as a result.
-    switch ((new ImmVector($args))->firstValue() ?? '') {
+    switch (C\first(vec($args)) ?? '') {
       case 'patch':
         $retry_count = 0;
         break;


### PR DESCRIPTION
`HH_IGNORE_ERROR` and `HH_FIXME` annoy me and there are a bunch that can be replaced with HSL functions:

* `\explode` becomes `Str\split` with args reversed
* `\array_key_exists` becomes `C\contains_key` with args reversed
* `\strncmp` can become `Str\starts_with`
* `\strncasecmp` can become `Str\starts_with_ci`
* `\str_pad` becomes `Str\pad_right`
* Empty string falsiness becomes `Str\is_empty`
* Hopefully, these are the last hack collections (`ImmVector`, `Vector`, and `Map`) to be converted to hack arrays