### PR TITLE
Fix broken tests using DataProvider

### DIFF
--- a/tests/importit/PathFiltersTest.php
+++ b/tests/importit/PathFiltersTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ImportIt;
 
 use namespace HH\Lib\{Keyset, Vec};
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 <<\Oncalls('open_source')>>
 final class PathFiltersTest extends \Facebook\ShipIt\BaseTest {

--- a/tests/importit/PathFiltersTest.php
+++ b/tests/importit/PathFiltersTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ImportIt;
 
 use namespace HH\Lib\{Keyset, Vec};
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 <<\Oncalls('open_source')>>
 final class PathFiltersTest extends \Facebook\ShipIt\BaseTest {

--- a/tests/importit/PathFiltersTest.php
+++ b/tests/importit/PathFiltersTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ImportIt;
 
 use namespace HH\Lib\{Keyset, Vec};
+use type Facebook\HackTest\DataProvider;
 
 <<\Oncalls('open_source')>>
 final class PathFiltersTest extends \Facebook\ShipIt\BaseTest {
@@ -49,7 +50,7 @@ final class PathFiltersTest extends \Facebook\ShipIt\BaseTest {
     ];
   }
 
-  <<\DataProvider('examplesForMoveDirectories')>>
+  <<DataProvider('examplesForMoveDirectories')>>
   public function testMoveDirectories(
     dict<string, string> $map,
     vec<string> $in,

--- a/tests/shipit/ConditionalLinesFilterTest.php
+++ b/tests/shipit/ConditionalLinesFilterTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{C};
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 <<\Oncalls('open_source')>>
 final class ConditionalLinesFilterTest extends BaseTest {

--- a/tests/shipit/ConditionalLinesFilterTest.php
+++ b/tests/shipit/ConditionalLinesFilterTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{C};
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 <<\Oncalls('open_source')>>
 final class ConditionalLinesFilterTest extends BaseTest {

--- a/tests/shipit/ConditionalLinesFilterTest.php
+++ b/tests/shipit/ConditionalLinesFilterTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{C};
+use type Facebook\HackTest\DataProvider;
 
 <<\Oncalls('open_source')>>
 final class ConditionalLinesFilterTest extends BaseTest {
@@ -67,7 +68,7 @@ final class ConditionalLinesFilterTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('testFilesProvider')>>
+  <<DataProvider('testFilesProvider')>>
   public function testUncommentLines(
     string $name,
     string $comment_start,

--- a/tests/shipit/FilterSanityCheckPhaseTest.php
+++ b/tests/shipit/FilterSanityCheckPhaseTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Str, Vec};
+use type Facebook\HackTest\DataProvider;
 
 
 <<\Oncalls('open_source')>>
@@ -40,7 +41,7 @@ final class FilterSanityCheckPhaseTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('exampleEmptyRoots')>>
+  <<DataProvider('exampleEmptyRoots')>>
   public function testAllowsIdentityFunctionForEmptyRoots(
     keyset<string> $roots,
   ): void {

--- a/tests/shipit/FilterSanityCheckPhaseTest.php
+++ b/tests/shipit/FilterSanityCheckPhaseTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Str, Vec};
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 
 <<\Oncalls('open_source')>>

--- a/tests/shipit/FilterSanityCheckPhaseTest.php
+++ b/tests/shipit/FilterSanityCheckPhaseTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Str, Vec};
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 
 <<\Oncalls('open_source')>>

--- a/tests/shipit/MessageSectionsTest.php
+++ b/tests/shipit/MessageSectionsTest.php
@@ -12,6 +12,7 @@
  */
 namespace Facebook\ShipIt;
 
+use type Facebook\HackTest\DataProvider;
 
 <<\Oncalls('open_source')>>
 final class MessageSectionsTest extends BaseTest {
@@ -40,7 +41,7 @@ final class MessageSectionsTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('examplesForGetSections')>>
+  <<DataProvider('examplesForGetSections')>>
   public function testGetSections(
     string $message,
     ?keyset<string> $valid,
@@ -66,7 +67,7 @@ final class MessageSectionsTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('examplesForBuildMessage')>>
+  <<DataProvider('examplesForBuildMessage')>>
   public function testBuildMessage(
     dict<string, string> $sections,
     string $expected,
@@ -84,7 +85,7 @@ final class MessageSectionsTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('getExamplesForWhitespaceEndToEnd')>>
+  <<DataProvider('getExamplesForWhitespaceEndToEnd')>>
   public function testWhitespaceEndToEnd(string $in, string $expected): void {
     $message = (new ShipItChangeset())
       ->withMessage($in)

--- a/tests/shipit/MessageSectionsTest.php
+++ b/tests/shipit/MessageSectionsTest.php
@@ -12,7 +12,7 @@
  */
 namespace Facebook\ShipIt;
 
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 <<\Oncalls('open_source')>>
 final class MessageSectionsTest extends BaseTest {

--- a/tests/shipit/MessageSectionsTest.php
+++ b/tests/shipit/MessageSectionsTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 <<\Oncalls('open_source')>>
 final class MessageSectionsTest extends BaseTest {

--- a/tests/shipit/PathFiltersTest.php
+++ b/tests/shipit/PathFiltersTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Keyset, Vec};
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 <<\Oncalls('open_source')>>
 final class PathFiltersTest extends BaseTest {

--- a/tests/shipit/PathFiltersTest.php
+++ b/tests/shipit/PathFiltersTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Keyset, Vec};
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 <<\Oncalls('open_source')>>
 final class PathFiltersTest extends BaseTest {

--- a/tests/shipit/PathFiltersTest.php
+++ b/tests/shipit/PathFiltersTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Keyset, Vec};
+use type Facebook\HackTest\DataProvider;
 
 <<\Oncalls('open_source')>>
 final class PathFiltersTest extends BaseTest {
@@ -60,7 +61,7 @@ final class PathFiltersTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('stripPathsTestData')>>
+  <<DataProvider('stripPathsTestData')>>
   public function testStripPaths(
     vec<string> $patterns,
     vec<string> $exceptions,
@@ -133,7 +134,7 @@ final class PathFiltersTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('examplesForMoveDirectories')>>
+  <<DataProvider('examplesForMoveDirectories')>>
   public function testMoveDirectories(
     dict<string, string> $map,
     vec<string> $in,
@@ -167,7 +168,7 @@ final class PathFiltersTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('examplesForStripExceptDirectories')>>
+  <<DataProvider('examplesForStripExceptDirectories')>>
   public function testStripExceptDirectories(
     keyset<string> $roots,
     vec<string> $paths_in,

--- a/tests/shipit/PathsWithSpacesTest.php
+++ b/tests/shipit/PathsWithSpacesTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Vec;
+use type Facebook\HackTest\DataProvider;
 
 
 <<\Oncalls('open_source')>>
@@ -27,7 +28,7 @@ final class PathsWithSpacesTest extends ShellTest {
     ];
   }
 
-  <<\DataProvider('exampleRepos')>>
+  <<DataProvider('exampleRepos')>>
   public function testPathWithSpace(ShipItTempDir $temp_dir): void {
     $repo = ShipItRepo::open($temp_dir->getPath(), '.');
     $head = $repo->getHeadChangeset();

--- a/tests/shipit/PathsWithSpacesTest.php
+++ b/tests/shipit/PathsWithSpacesTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Vec;
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 
 <<\Oncalls('open_source')>>

--- a/tests/shipit/PathsWithSpacesTest.php
+++ b/tests/shipit/PathsWithSpacesTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Vec;
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 
 <<\Oncalls('open_source')>>

--- a/tests/shipit/SymlinkTest.php
+++ b/tests/shipit/SymlinkTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{C, Vec};
+use type Facebook\HackTest\DataProvider;
 
 
 enum SymlinkTestOperation: string {
@@ -103,7 +104,7 @@ final class SymlinkTest extends ShellTest {
    * 2. create the new thing
    *
    */
-  <<\DataProvider('getFileToFromSymlinkExamples')>>
+  <<DataProvider('getFileToFromSymlinkExamples')>>
   public function testFileToFromSymlink(
     classname<ShipItSourceRepo> $repo_type,
     vec<vec<string>> $steps,

--- a/tests/shipit/SymlinkTest.php
+++ b/tests/shipit/SymlinkTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{C, Vec};
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 
 enum SymlinkTestOperation: string {

--- a/tests/shipit/SymlinkTest.php
+++ b/tests/shipit/SymlinkTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{C, Vec};
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 
 enum SymlinkTestOperation: string {

--- a/tests/shipit/UnicodeTest.php
+++ b/tests/shipit/UnicodeTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Str;
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 <<\Oncalls('open_source')>>
 final class UnicodeTest extends ShellTest {

--- a/tests/shipit/UnicodeTest.php
+++ b/tests/shipit/UnicodeTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Str;
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 <<\Oncalls('open_source')>>
 final class UnicodeTest extends ShellTest {

--- a/tests/shipit/UnicodeTest.php
+++ b/tests/shipit/UnicodeTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Str;
+use type Facebook\HackTest\DataProvider;
 
 <<\Oncalls('open_source')>>
 final class UnicodeTest extends ShellTest {
@@ -67,7 +68,7 @@ final class UnicodeTest extends ShellTest {
     ];
   }
 
-  <<\DataProvider('getSourceRepoImplementations')>>
+  <<DataProvider('getSourceRepoImplementations')>>
   public function testCommitMessage(
     classname<ShipItSourceRepo> $impl,
     string $header_file,

--- a/tests/shipit/UnusualContentTest.php
+++ b/tests/shipit/UnusualContentTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Str, C, Vec};
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider; // @oss-enable
 
 <<\Oncalls('open_source')>>
 final class UnusualContentTest extends BaseTest {

--- a/tests/shipit/UnusualContentTest.php
+++ b/tests/shipit/UnusualContentTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Str, C, Vec};
+use type Facebook\HackTest\DataProvider;
 
 <<\Oncalls('open_source')>>
 final class UnusualContentTest extends BaseTest {
@@ -42,7 +43,7 @@ final class UnusualContentTest extends BaseTest {
    * an invalid patch.
    *
    */
-  <<\DataProvider('examplesForRemovingFile')>>
+  <<DataProvider('examplesForRemovingFile')>>
   public function testRemovingFile(
     string $header_file,
     string $patch_file,

--- a/tests/shipit/UnusualContentTest.php
+++ b/tests/shipit/UnusualContentTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\{Str, C, Vec};
 use type Facebook\HackTest\DataProvider; // @oss-enable
+// @oss-disable: use type DataProvider;
 
 <<\Oncalls('open_source')>>
 final class UnusualContentTest extends BaseTest {

--- a/tests/shipit/UserFiltersTest.php
+++ b/tests/shipit/UserFiltersTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Str;
-use type Facebook\HackTest\DataProvider;// @oss-enable
+use type Facebook\HackTest\DataProvider; // @oss-enable
 // @oss-disable: use type DataProvider;
 
 final class UserInfoTestImplementation extends ShipItUserInfo {

--- a/tests/shipit/UserFiltersTest.php
+++ b/tests/shipit/UserFiltersTest.php
@@ -13,6 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Str;
+use type Facebook\HackTest\DataProvider;
 
 final class UserInfoTestImplementation extends ShipItUserInfo {
   <<__Override>>
@@ -43,7 +44,7 @@ final class UserFiltersTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('examplesForGetMentions')>>
+  <<DataProvider('examplesForGetMentions')>>
   public function testGetMentions(
     string $message,
     keyset<string> $expected,
@@ -78,7 +79,7 @@ final class UserFiltersTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('rewriteMentionsExamples')>>
+  <<DataProvider('rewriteMentionsExamples')>>
   public function testRewriteMentions(
     string $message,
     (function(string): string) $callback,
@@ -105,7 +106,7 @@ final class UserFiltersTest extends BaseTest {
     ];
   }
 
-  <<\DataProvider('examplesForSVNUserMapping')>>
+  <<DataProvider('examplesForSVNUserMapping')>>
   public function testSVNUserMapping(string $in, string $expected): void {
     $changeset = (new ShipItChangeset())->withAuthor($in)
       |> ShipItUserFilters::rewriteSVNAuthor(

--- a/tests/shipit/UserFiltersTest.php
+++ b/tests/shipit/UserFiltersTest.php
@@ -14,6 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Str;
 use type Facebook\HackTest\DataProvider;// @oss-enable
+// @oss-disable: use type DataProvider;
 
 final class UserInfoTestImplementation extends ShipItUserInfo {
   <<__Override>>

--- a/tests/shipit/UserFiltersTest.php
+++ b/tests/shipit/UserFiltersTest.php
@@ -13,7 +13,7 @@
 namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Str;
-use type Facebook\HackTest\DataProvider;
+use type Facebook\HackTest\DataProvider;// @oss-enable
 
 final class UserInfoTestImplementation extends ShipItUserInfo {
   <<__Override>>

--- a/tests/shipit/github/annotations.php
+++ b/tests/shipit/github/annotations.php
@@ -13,11 +13,6 @@ class Oncalls implements HH\ClassAttribute, HH\MethodAttribute, HH\TypeAliasAttr
   public function __construct(mixed ...$args) {}
 }
 
-class DataProvider implements HH\ClassAttribute, HH\MethodAttribute, HH\TypeAliasAttribute,
-    HH\EnumAttribute, HH\FunctionAttribute {
-  public function __construct(mixed ...$args) {}
-}
-
 class TestsBypassVisibility implements HH\ClassAttribute, HH\MethodAttribute, HH\TypeAliasAttribute,
     HH\EnumAttribute, HH\FunctionAttribute {
   public function __construct(mixed ...$args) {}


### PR DESCRIPTION
This should fix the tests externally but I'm pretty sure this will break when imported due to namespacing differences. Glancing through the other FB hacklang repos I think un-namespacing the tests might be the best thing to do?

CC @fredemmott 