### PR TITLE
[EASY] Cleanup unnecessary 'autoload' section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,5 @@
   "require-dev": {
     "hhvm/hacktest": "~2.0",
     "facebook/fbexpect": "^2.6.1"
-  },
-  "autoload": {
-    "classmap": [
-      "src/",
-      "tests/",
-      "demo"
-    ]
   }
 }


### PR DESCRIPTION
`hhvm-autoload` uses the entries in `hh_autoload.json`. I think it's easier to maintain if the paths are only listed in one place.