### PR TITLE
Don't typecheck the (unused) autoload.php file

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -2,4 +2,4 @@ assume_php = false
 safe_array = true
 safe_vector_array = true
 version = 3.0.0
-ignored_paths = [ "^vendor/.*/tests?/" ]
+ignored_paths = [ "^vendor/.*/tests?/", "vendor/autoload.php" ]


### PR DESCRIPTION
As far as I can tell from reading the documentation, there is no way to stop composer from generating its `autoload.php` :(

@fredemmott Sorry for pinging you so often, but I want to make sure this is the right thing to do to fix CI. I took a look at some other `hhvm/` projects and no project seems to have fixed this yet.