### PR TITLE
Improve QoL for OSS users of FBShipIt

### DIFF
--- a/demo/run_shipit.php
+++ b/demo/run_shipit.php
@@ -9,9 +9,11 @@
 namespace Facebook\ShipIt;
 
 final class ShipDemoProject {
+  private static string $sourceRoot = "fb-examples";
+
   public static function getPathMappings(): dict<string, string> {
     return dict[
-      'fb-examples' => 'examples',
+      self::$sourceRoot => 'examples',
     ];
   }
 
@@ -19,25 +21,9 @@ final class ShipDemoProject {
     ShipItChangeset $changeset,
   ): ShipItChangeset {
     return $changeset
-      |> ShipItPathFilters::stripPaths(
+      |> ShipItPathFilters::stripExceptSourceRoots(
         $$,
-        vec[
-          "/^src/",
-          "/^tests/",
-          "/^\.gitignore$/",
-          "/^\.hhconfig$/",
-          "/^\.travis\.sh$/",
-          "/^\.travis\.yml$/",
-          "/^CODE_OF_CONDUCT\.md$/",
-          "/^CONTRIBUTING\.md$/",
-          "/^DEBUGGING\.md$/",
-          "/^README\.md$/",
-          "/^TESTING\.md$/",
-          "/^composer\.json$/",
-          "/^composer\.lock$/",
-          "/^hh_autoload\.json$/",
-          "/^phpunit\.xml$/",
-        ],
+        keyset[self::$sourceRoot]
       )
       |> ShipItPathFilters::moveDirectories($$, self::getPathMappings());
   }
@@ -47,7 +33,7 @@ final class ShipDemoProject {
       /* default working dir = */ '/var/tmp/shipit',
       /* source repo name */ 'fbshipit',
       /* destination repo name */ 'fbshipit-target',
-      /* source roots */ keyset['.'],
+      /* source roots */ keyset[self::$sourceRoot],
     );
 
     $phases = vec[

--- a/fb-examples/lib/config/FBShipItConfig.php-example
+++ b/fb-examples/lib/config/FBShipItConfig.php-example
@@ -157,7 +157,10 @@ abstract class FBShipItConfig {
     bool $use_confidential_filter = true,
   ): ShipItChangeset {
     $changeset = $changeset
-      |> $this->stripExceptSourceRoots($$, $branch_config)
+      |> ShipItPathFilters::stripExceptSourceRoots(
+        $$,
+        $this->getBaseConfig($branch_config)->getSourceRoots(),
+      )
       |> $this->filterSubmodules($$)
       |> (
         $this->getProjectFilterChangesetFn($branch_config)
@@ -231,21 +234,6 @@ abstract class FBShipItConfig {
       ->withSourceBranch($branch_config['internal'])
       ->withDestinationBranch($branch_config['external'])
       ->withCommitMarkerPrefix(true);
-  }
-
-  final protected function stripExceptSourceRoots(
-    ShipItChangeset $changeset,
-    FBSourceBranchConfig $branch_config,
-  ): ShipItChangeset {
-    $roots = Keyset\filter(
-      $this->getBaseConfig($branch_config)->getSourceRoots(),
-      $root ==> $root !== '',
-    );
-    if (C\is_empty($roots)) {
-      return $changeset;
-    }
-
-    return ShipItPathFilters::stripExceptDirectories($changeset, $roots);
   }
 
   final protected function filterSubmodules(
@@ -476,7 +464,8 @@ abstract class FBShipItConfig {
       new ShipItCleanPhase(ShipItRepoSide::DESTINATION),
       new ShipItPullPhase(ShipItRepoSide::DESTINATION),
       new ImportItSyncPhase(
-        $changeset ==> $this->projectImportChangeset($changeset, $branch_config),
+        $changeset ==>
+          $this->projectImportChangeset($changeset, $branch_config),
       ),
     ];
   }
@@ -694,12 +683,8 @@ abstract class FBShipItConfig {
     ShipItChangeset $old_changeset,
     ShipItChangeset $new_changeset,
   ): string {
-    $old_parsed = self::getSubmoduleCommitLinks(
-      $old_changeset->getMessage(),
-    );
-    $new_parsed = self::getSubmoduleCommitLinks(
-      $new_changeset->getMessage(),
-    );
+    $old_parsed = self::getSubmoduleCommitLinks($old_changeset->getMessage());
+    $new_parsed = self::getSubmoduleCommitLinks($new_changeset->getMessage());
     $prefix = null;
     $suffix = null;
     if ($old_parsed !== null) {

--- a/src/shipit/filter/ShipItPathFilters.php
+++ b/src/shipit/filter/ShipItPathFilters.php
@@ -168,4 +168,16 @@ abstract final class ShipItPathFilters {
     }
     return $changeset->withDiffs($diffs);
   }
+
+  public static function stripExceptSourceRoots(
+    ShipItChangeset $changeset,
+    keyset<string> $source_roots,
+  ): ShipItChangeset {
+    $roots = Keyset\filter($source_roots, $root ==> $root !== '');
+    if (C\is_empty($roots)) {
+      return $changeset;
+    }
+
+    return self::stripExceptDirectories($changeset, $roots);
+  }
 }


### PR DESCRIPTION
Summary:
This is a minor refactor that makes it a little easier to work with the public version of shipit.

I found when writing the demo that it was odd that there was no built-in filter to do this, but I realize now that's because in the OSS version it's tucked away in fb-examples and I missed it.

Differential Revision: D21642531

