### PR TITLE
Make entrypoints async

### DIFF
--- a/demo/run_importit.php
+++ b/demo/run_importit.php
@@ -35,7 +35,7 @@ final class ImportDemoProject {
       );
   }
 
-  public static function cliMain(): void {
+  public static async function cliMainAsync(): Awaitable<void> {
     $config = new ShipItBaseConfig(
       /* default working dir = */ '/var/tmp/shipit',
       /* source repo name */ 'fbshipit-target',
@@ -71,5 +71,5 @@ final class ImportDemoProject {
 async function mainAsync(): Awaitable<void> {
   require_once(\dirname(__DIR__).'/vendor/autoload.hack'); // @oss-enable
   \Facebook\AutoloadMap\initialize(); // @oss-enable
-  ImportDemoProject::cliMain();
+  await ImportDemoProject::cliMainAsync();
 }

--- a/demo/run_shipit.php
+++ b/demo/run_shipit.php
@@ -28,7 +28,7 @@ final class ShipDemoProject {
       |> ShipItPathFilters::moveDirectories($$, self::getPathMappings());
   }
 
-  public static function cliMain(): void {
+  public static async function cliMainAsync(): Awaitable<void> {
     $config = new ShipItBaseConfig(
       /* default working dir = */ '/var/tmp/shipit',
       /* source repo name */ 'fbshipit',
@@ -72,5 +72,5 @@ final class ShipDemoProject {
 async function mainAsync(): Awaitable<void> {
   require_once(\dirname(__DIR__).'/vendor/autoload.hack'); // @oss-enable
   \Facebook\AutoloadMap\initialize(); // @oss-enable
-  ShipDemoProject::cliMain();
+  await ShipDemoProject::cliMainAsync();
 }

--- a/fb-examples/lib/importit/FBImportItCLI.php-example
+++ b/fb-examples/lib/importit/FBImportItCLI.php-example
@@ -146,7 +146,7 @@ abstract class FBImportItCLI
   }
 
   <<__Override>>
-  final public static function cliMain(): void {
-    self::cliForBinary(static::class);
+  final public static async function cliMainAsync(): Awaitable<void> {
+    await self::cliForBinaryAsync(static::class);
   }
 }

--- a/fb-examples/lib/shipit/FBShipItCLITrait.php-example
+++ b/fb-examples/lib/shipit/FBShipItCLITrait.php-example
@@ -38,21 +38,21 @@ trait FBShipItCLITrait {
     throw new ShipItExitException(128);
   }
 
-  abstract public static function cliMain(): void;
+  abstract public static function cliMainAsync(): Awaitable<void>;
 
-  final public static function cliForBinary(
+  final public static async function cliForBinaryAsync(
     classname<IShipItConfig> $config_class,
-  ): void {
+  ): Awaitable<void> {
     ShipItLogger::out("--- Starting %s\n", $config_class);
     $config = $config_class::getBaseConfig();
     $runner = new ShipItPhaseRunner($config, $config_class::getPhases());
     self::executeRunner($runner);
   }
 
-  final public static function cliShipIt(
+  final public static async function cliShipItAsync(
     ?FBShipItConfigeratorConfig $config = null,
     ?string $_external_branch = null,
-  ): void {
+  ): Awaitable<void> {
     $config_name = $config === null ? '' : $config->getConfigeratorName();
     ShipItLogger::out("--- Starting ShipIt: %s\n", $config_name);
     $runner = new FBShipItProjectRunner(
@@ -62,10 +62,10 @@ trait FBShipItCLITrait {
     self::executeRunner($runner);
   }
 
-  final public static function cliImportIt(
+  final public static async function cliImportItAsync(
     ?FBShipItConfigeratorConfig $config = null,
     ?string $external_branch = null,
-  ): void {
+  ): Awaitable<void> {
     $config_name = $config === null ? '' : $config->getConfigeratorName();
     ShipItLogger::out("--- Starting ImportIt: %s\n", $config_name);
     $runner = new FBShipItProjectRunner(


### PR DESCRIPTION
Summary:
Long term, ShipIt will need to be async to support HSL IO and to stop using `awaitSynchrounously` in a few places. This is the first of several diffs to async-ify ShipIt.

I converted everything in one giant, painful commit over the course of several days and then I've been working on splitting it into review-sized diffs. Knowing the end-game has some advantages for me as the author but a few changes might look odd or unnecessary in each individual diff for the reviewer.

Differential Revision: D22168831

