### PR TITLE
Support rewriting C++ include directives

### DIFF
--- a/fb-examples/lib/config/FBShipItConfig.php-example
+++ b/fb-examples/lib/config/FBShipItConfig.php-example
@@ -86,6 +86,18 @@ abstract class FBShipItConfig {
       )
       |> ShipItPathFilters::moveDirectories($$, $get_path_mappings());
 
+    if ($this->rewriteCppIncludeDirectives()) {
+      $standard_filters = ShipItPathFilters::rewriteCppIncludeDirectivePaths(
+        $changeset,
+        Dict\map_keys(
+          $get_path_mappings(),
+          // #include directive paths in fbsource do not include fbcode. These
+          // need to be stripped so we can actually map these directives.
+          ($src) ==> Str\strip_prefix($src, "fbcode/"),
+        ),
+      );
+    }
+
     $marker = $this->getCommentMarker();
     if ($marker === null) {
       return $standard_filters;
@@ -158,6 +170,10 @@ abstract class FBShipItConfig {
    */
   public function referencePullRequestNumber(): bool {
     return true;
+  }
+
+  public function rewriteCppIncludeDirectives(): bool {
+    return false;
   }
 
   // Public so that you can add a unit test
@@ -376,6 +392,18 @@ abstract class FBShipItConfig {
         Vec\keys($this->getSubmoduleMappings())
           |> Vec\map($$, $path ==> '@^'.$path.'$@'),
       );
+
+    if ($this->rewriteCppIncludeDirectives()) {
+      $standard_filters = ImportItPathFilters::rewriteCppIncludeDirectivePaths(
+        $standard_filters,
+        Dict\map_keys(
+          ($this->getPathMappingsFn($branch_config))(),
+          // #include directive paths in fbsource do not include fbcode. These
+          // need to be stripped so imports will be valid in fbsource.
+          ($src) ==> Str\strip_prefix($src, "fbcode/"),
+        ),
+      );
+    }
 
     $marker = $this->getCommentMarker();
     if ($marker === null) {

--- a/src/importit/filter/ImportItPathFilters.php
+++ b/src/importit/filter/ImportItPathFilters.php
@@ -38,6 +38,22 @@ abstract final class ImportItPathFilters {
   }
 
   /**
+   * Rewrite C/C++ #include directives using path mappings.
+   *
+   * E.g. `#include "src/header.h"` imports to `#include "deep/project/header.h"`.
+   */
+  public static function rewriteCppIncludeDirectivePaths(
+    \Facebook\ShipIt\ShipItChangeset $changeset,
+    dict<string, string> $path_mappings,
+  ): \Facebook\ShipIt\ShipItChangeset {
+    $path_mappings = self::invertShipIt($path_mappings);
+    return \Facebook\ShipIt\ShipItPathFilters::rewriteCppIncludeDirectivePaths(
+      $changeset,
+      $path_mappings,
+    );
+  }
+
+  /**
    * Invert this ShipIt map, throwing on any keys that would be duplicated.
    *
    * @param $shipit_mapping the mapping to invert


### PR DESCRIPTION
Summary:
After some discussions with some C++ folks, I think we can improve how we handle projects that aren't hosted at the root level of the source repo.

C++ conventions at FB prefer absolute paths for `#include "x"` directives, for example in a fictional `fbsource/fbcode/some/deep/project/file.cpp`:

```
#include <functional> // a stdlib header
#include "some/deep/project/header.h"
```

The problem is that when this file is exported to GitHub we would map "some/deep/project/" to "project/" with ShipIt so that the includes in that file no longer make sense. This is what we should export:

```
#include <functional> // a stdlib header
#include "project/header.h"
```

Historically this hasn't been a problem because our C++ open sourced projects have been hosted at the root level (e.g. `fbsource/fbcode/folly/*`). However, we have a few projects that are running up against this problem and we should try and make it as easy as possible to make a project open source **and** comply with internal conventions

Reviewed By: yfeldblum, yns88

Differential Revision: D22559398

