### PR TITLE
Update CI version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       # Test multiple HHVM versions
       matrix:
-        hhvm: [latest, 4.56-latest, 4.32-latest]
+        hhvm: [latest]
     runs-on: ubuntu-latest
     container:
       image: hhvm/hhvm:${{ matrix.hhvm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       # Test multiple HHVM versions
       matrix:
-        hhvm: [latest]
+        hhvm: [latest, 4.64-latest]
     runs-on: ubuntu-latest
     container:
       image: hhvm/hhvm:${{ matrix.hhvm }}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "keywords": [ "Facebook", "FBShipIt", "Hack" ],
   "license": [ "MIT" ],
   "require": {
-    "hhvm": "~4.8",
+    "hhvm": "~4.64",
     "hhvm/hsl": "~4.0",
     "hhvm/hsl-experimental": "~4.0",
     "hhvm/hhvm-autoload": "~3.0",


### PR DESCRIPTION
Summary: The `\is_array` to `\HH\is_any_array` migration in D23010247 (https://github.com/facebook/fbshipit/commit/863a69437de85b726118b22b7ece228a1b8431f9) broke OSS CI because this function wasn't available until more recently than those LTS releases.

Differential Revision: D23105597

