### PR TITLE
Rename ShipItBaseConfig to ShipItManifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ a Changeset, and return a new, modified one.
 ## Using FBShipIt
 
 You need to construct:
- - a `ShipItBaseConfig` object, defining your default working directory, and the directory names of your source and destination repositories
+ - a `ShipItManifest` object, defining your default working directory, and the directory names of your source and destination repositories
  - a list of phases you want to run
  - a pipeline of filters, assuming you are using the `ShipItSyncPhase`
 

--- a/demo/DemoSourceInitPhase.php
+++ b/demo/DemoSourceInitPhase.php
@@ -34,8 +34,8 @@ final class DemoSourceRepoInitPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  public function runImpl(ShipItBaseConfig $config): void {
-    $local_path = $config->getSourcePath();
+  public function runImpl(ShipItManifest $manifest): void {
+    $local_path = $manifest->getSourcePath();
 
     /* HH_FIXME[2049] __PHPStdLib */
     /* HH_FIXME[4107] __PHPStdLib */

--- a/demo/README.md
+++ b/demo/README.md
@@ -59,7 +59,7 @@ In this demo, we only want the `fb-examples` folder, so all other paths are stri
 ## 4. Base Config
 
 When the source and destination repositories are cloned to the local system, they use
-the paths provided by the `ShipItBaseConfig`. For the default working dir,
+the paths provided by the `ShipItManifest`. For the default working dir,
 `/var/tmp/shipit` is the conventional location. While the source and destination repo
 names can be anything they are, by convention, the names of the actual repositories.
 

--- a/demo/run_importit.php
+++ b/demo/run_importit.php
@@ -13,7 +13,7 @@ use type Facebook\ShipIt\{
   DemoGitHubUtils,
   DemoSourceRepoInitPhase,
   ShipItPhaseRunner,
-  ShipItBaseConfig,
+  ShipItManifest,
   ShipItChangeset,
   ShipItCleanPhase,
   ShipItPullPhase,
@@ -36,7 +36,7 @@ final class ImportDemoProject {
   }
 
   public static function cliMain(): void {
-    $config = new ShipItBaseConfig(
+    $manifest = new ShipItManifest(
       /* default working dir = */ '/var/tmp/shipit',
       /* source repo name */ 'fbshipit-target',
       /* destination repo name */ 'fbshipit',
@@ -60,7 +60,7 @@ final class ImportDemoProject {
     ];
 
     try {
-      (new ShipItPhaseRunner($config, $phases))->run();
+      (new ShipItPhaseRunner($manifest, $phases))->run();
     } catch (ShipItExitException $e) {
       exit($e->exitCode);
     }

--- a/demo/run_shipit.php
+++ b/demo/run_shipit.php
@@ -29,7 +29,7 @@ final class ShipDemoProject {
   }
 
   public static function cliMain(): void {
-    $config = new ShipItBaseConfig(
+    $manifest = new ShipItManifest(
       /* default working dir = */ '/var/tmp/shipit',
       /* source repo name */ 'fbshipit',
       /* destination repo name */ 'fbshipit-target',
@@ -61,7 +61,7 @@ final class ShipDemoProject {
     ];
 
     try {
-      (new ShipItPhaseRunner($config, $phases))->run();
+      (new ShipItPhaseRunner($manifest, $phases))->run();
     } catch (ShipItExitException $e) {
       exit($e->exitCode);
     }

--- a/fb-examples/lib/config/FBShipItConfig.php-example
+++ b/fb-examples/lib/config/FBShipItConfig.php-example
@@ -194,7 +194,7 @@ abstract class FBShipItConfig {
     $changeset = $changeset
       |> ShipItPathFilters::stripExceptSourceRoots(
         $$,
-        $this->getBaseConfig($branch_config)->getSourceRoots(),
+        $this->getManifest($branch_config)->getSourceRoots(),
       )
       |> $this->filterSubmodules($$)
       |> (
@@ -250,12 +250,12 @@ abstract class FBShipItConfig {
     return $roots;
   }
 
-  public function getBaseConfig(
+  public function getManifest(
     FBSourceBranchConfig $branch_config,
-  ): ShipItBaseConfig {
+  ): ShipItManifest {
     $static_config = $this->getStaticConfig();
     return (
-      new ShipItBaseConfig(
+      new ShipItManifest(
         '/var/tmp/fbshipit',
         /* source_dir = */ $static_config['internalRepo'],
         Shapes::idx(
@@ -443,13 +443,13 @@ abstract class FBShipItConfig {
       );
   }
 
-  final public function getImportBaseConfig(
+  final public function getImportManifest(
     FBSourceBranchConfig $branch_config,
-  ): ShipItBaseConfig {
+  ): ShipItManifest {
     $static_config = $this->getStaticConfig();
-    $shipit_base_config = $this->getBaseConfig($branch_config);
+    $shipit_manifest = $this->getManifest($branch_config);
     return (
-      new ShipItBaseConfig(
+      new ShipItManifest(
         /* base_dir = */ '/var/tmp/fbimportit',
         /* source_dir */ Shapes::idx(
           $static_config,
@@ -461,8 +461,8 @@ abstract class FBShipItConfig {
         /* source_roots = */ keyset[],
       )
     )
-      ->withSourceBranch($shipit_base_config->getDestinationBranch())
-      ->withDestinationBranch($shipit_base_config->getSourceBranch())
+      ->withSourceBranch($shipit_manifest->getDestinationBranch())
+      ->withDestinationBranch($shipit_manifest->getSourceBranch())
       ->withCommitMarkerPrefix(true);
   }
 

--- a/fb-examples/lib/importit/FBImportItBranchResolutionPhase.php-example
+++ b/fb-examples/lib/importit/FBImportItBranchResolutionPhase.php-example
@@ -39,7 +39,7 @@ final class FBImportItBranchResolutionPhase
     ?IShipItArgumentParser $argument_parser = null,
   ): ShipItPhaseRunner {
     return new ShipItPhaseRunner(
-      $config_object->getImportBaseConfig($branch_config),
+      $config_object->getImportManifest($branch_config),
       $config_object->getImportPhases($branch_config),
       $argument_parser,
     );

--- a/fb-examples/lib/importit/FBRepoInitPhase.php-example
+++ b/fb-examples/lib/importit/FBRepoInitPhase.php-example
@@ -51,10 +51,10 @@ final class FBRepoInitPhase extends \Facebook\ShipIt\ShipItPhase {
   }
 
   <<__Override>>
-  public function runImpl(\Facebook\ShipIt\ShipItBaseConfig $config): void {
+  public function runImpl(\Facebook\ShipIt\ShipItManifest $manifest): void {
     $local_path = $this->side === \Facebook\ShipIt\ShipItRepoSide::SOURCE
-      ? $config->getSourcePath()
-      : $config->getDestinationPath();
+      ? $manifest->getSourcePath()
+      : $manifest->getDestinationPath();
 
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */

--- a/fb-examples/lib/shipit/FBRepoInitPhase.php-example
+++ b/fb-examples/lib/shipit/FBRepoInitPhase.php-example
@@ -57,10 +57,10 @@ final class FBRepoInitPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  public function runImpl(ShipItBaseConfig $config): void {
+  public function runImpl(ShipItManifest $manifest): void {
     $local_path = $this->side === ShipItRepoSide::SOURCE
-      ? $config->getSourcePath()
-      : $config->getDestinationPath();
+      ? $manifest->getSourcePath()
+      : $manifest->getDestinationPath();
 
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */

--- a/fb-examples/lib/shipit/FBShipItBranchResolutionPhase.php-example
+++ b/fb-examples/lib/shipit/FBShipItBranchResolutionPhase.php-example
@@ -73,7 +73,7 @@ class FBShipItBranchResolutionPhase extends ShipItPhase {
     ?IShipItArgumentParser $argument_parser = null,
   ): ShipItPhaseRunner {
     return new ShipItPhaseRunner(
-      $config_object->getBaseConfig($branch_config),
+      $config_object->getManifest($branch_config),
       $config_object->getPhases($branch_config),
       $argument_parser,
     );
@@ -127,7 +127,7 @@ class FBShipItBranchResolutionPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  public function runImpl(ShipItBaseConfig $_config): void {
+  public function runImpl(ShipItManifest $_manifest): void {
     $config_object = $this->configObject;
     $branch_configs = $this->getBranchConfigs();
     if ($this->repoMetadataFile !== null) {

--- a/fb-examples/lib/shipit/FBShipItPreview.php-example
+++ b/fb-examples/lib/shipit/FBShipItPreview.php-example
@@ -122,7 +122,7 @@ order to preview the full patch.';
       );
       foreach ($branch_configs as $branch_config) {
         $source_roots =
-          $config_object->getBaseConfig($branch_config)->getSourceRoots();
+          $config_object->getManifest($branch_config)->getSourceRoots();
         $changeset_paths = Vec\map(
           $changeset->getDiffs(),
           ($diff) ==> $diff['path'],

--- a/fb-examples/lib/shipit/FBShipItProjectRunner.php-example
+++ b/fb-examples/lib/shipit/FBShipItProjectRunner.php-example
@@ -33,7 +33,7 @@ final class FBShipItProjectRunner extends ShipItPhaseRunner {
     private ?string $externalBranch = null,
     ?IShipItArgumentParser $argumentParser = null,
   ) {
-    $config = new ShipItBaseConfig(
+    $manifest = new ShipItManifest(
       '/var/tmp/fbshipit',
       'shipit',
       'shipit',
@@ -41,7 +41,7 @@ final class FBShipItProjectRunner extends ShipItPhaseRunner {
     );
     if ($configObject !== null) {
       parent::__construct(
-        $config,
+        $manifest,
         self::getPhases(
           $action,
           $configObject,
@@ -51,7 +51,7 @@ final class FBShipItProjectRunner extends ShipItPhaseRunner {
         $argumentParser,
       );
     } else {
-      parent::__construct($config, vec[], $argumentParser);
+      parent::__construct($manifest, vec[], $argumentParser);
     }
   }
 
@@ -68,7 +68,7 @@ final class FBShipItProjectRunner extends ShipItPhaseRunner {
         'long_name' => 'verbose',
         'description' => 'Give more verbose output',
         'write' => $_ ==> {
-          $this->config = $this->config->withVerboseEnabled();
+          $this->manifest = $this->manifest->withVerboseEnabled();
           ShipItScopedFlock::$verbose = ShipItScopedFlock::DEBUG_EXCLUSIVE;
           return true;
         },

--- a/src/shipit/ShipItBaseConfig.php
+++ b/src/shipit/ShipItBaseConfig.php
@@ -14,7 +14,7 @@ namespace Facebook\ShipIt;
 
 use namespace HH\Lib\Str;
 
-final class ShipItBaseConfig {
+final class ShipItManifest {
   public function __construct(
     private string $baseDirectoryPath,
     private string $defaultSourceDirectoryName,
@@ -201,8 +201,8 @@ final class ShipItBaseConfig {
   }
 
   private function modified<Tignored>(
-    (function(ShipItBaseConfig): Tignored) $mutator,
-  ): ShipItBaseConfig {
+    (function(ShipItManifest): Tignored) $mutator,
+  ): ShipItManifest {
     $ret = clone $this;
     $mutator($ret);
     return $ret;

--- a/src/shipit/ShipItSyncConfig.php
+++ b/src/shipit/ShipItSyncConfig.php
@@ -14,7 +14,7 @@ namespace Facebook\ShipIt;
 
 final class ShipItSyncConfig {
   const type TFilterFn = (function(
-    ShipItBaseConfig,
+    ShipItManifest,
     ShipItChangeset,
   ): ShipItChangeset);
   const type TPostFilterChangesetsFn = (function(
@@ -96,7 +96,7 @@ final class ShipItSyncConfig {
   }
 
   public function getFilter(
-  ): (function(ShipItBaseConfig, ShipItChangeset): ShipItChangeset) {
+  ): (function(ShipItManifest, ShipItChangeset): ShipItChangeset) {
     return $this->filter;
   }
 

--- a/src/shipit/phase/ShipItAssertValidFilterPhase.php
+++ b/src/shipit/phase/ShipItAssertValidFilterPhase.php
@@ -44,8 +44,8 @@ final class ShipItAssertValidFilterPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  protected function runImpl(ShipItBaseConfig $config): void {
-    $this->assertValid($config->getSourceRoots());
+  protected function runImpl(ShipItManifest $manifest): void {
+    $this->assertValid($manifest->getSourceRoots());
   }
 
   // Public for testing

--- a/src/shipit/phase/ShipItCleanPhase.php
+++ b/src/shipit/phase/ShipItCleanPhase.php
@@ -37,17 +37,17 @@ final class ShipItCleanPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  final protected function runImpl(ShipItBaseConfig $config): void {
+  final protected function runImpl(ShipItManifest $manifest): void {
     switch ($this->side) {
       case ShipItRepoSide::SOURCE:
-        $lock = $config->getSourceSharedLock();
-        $local_path = $config->getSourcePath();
-        $branch = $config->getSourceBranch();
+        $lock = $manifest->getSourceSharedLock();
+        $local_path = $manifest->getSourcePath();
+        $branch = $manifest->getSourceBranch();
         break;
       case ShipItRepoSide::DESTINATION:
-        $lock = $config->getDestinationSharedLock();
-        $local_path = $config->getDestinationPath();
-        $branch = $config->getDestinationBranch();
+        $lock = $manifest->getDestinationSharedLock();
+        $local_path = $manifest->getDestinationPath();
+        $branch = $manifest->getDestinationBranch();
         break;
     }
     ShipItRepo::open($lock, $local_path, $branch)->clean();

--- a/src/shipit/phase/ShipItDeleteCorruptedRepoPhase.php
+++ b/src/shipit/phase/ShipItDeleteCorruptedRepoPhase.php
@@ -42,10 +42,10 @@ final class ShipItDeleteCorruptedRepoPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  public function runImpl(ShipItBaseConfig $config): void {
+  public function runImpl(ShipItManifest $manifest): void {
     $local_path = $this->side === ShipItRepoSide::SOURCE
-      ? $config->getSourcePath()
-      : $config->getDestinationPath();
+      ? $manifest->getSourcePath()
+      : $manifest->getDestinationPath();
 
     /* HH_FIXME[2049] __PHPStdLib */
     /* HH_FIXME[4107] __PHPStdLib */

--- a/src/shipit/phase/ShipItGitHubInitPhase.php
+++ b/src/shipit/phase/ShipItGitHubInitPhase.php
@@ -92,11 +92,11 @@ final class ShipItGitHubInitPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  public function runImpl(ShipItBaseConfig $config): void {
+  public function runImpl(ShipItManifest $manifest): void {
     $class = $this->githubUtils;
     $local_path = $this->side === ShipItRepoSide::SOURCE
-      ? $config->getSourcePath()
-      : $config->getDestinationPath();
+      ? $manifest->getSourcePath()
+      : $manifest->getDestinationPath();
 
     $credentials = null;
     if ($this->transport !== ShipItTransport::SSH && !$this->anonymousHttps) {

--- a/src/shipit/phase/ShipItPhase.php
+++ b/src/shipit/phase/ShipItPhase.php
@@ -16,7 +16,7 @@ abstract class ShipItPhase {
   private bool $skipped = false;
 
   abstract public function getReadableName(): string;
-  abstract protected function runImpl(ShipItBaseConfig $config): void;
+  abstract protected function runImpl(ShipItManifest $manifest): void;
 
   /**
    * This allows you to build multi-project automation.
@@ -48,11 +48,11 @@ abstract class ShipItPhase {
     $this->skipped = false;
   }
 
-  final public function run(ShipItBaseConfig $config): void {
-    $logger = new ShipItVerboseLogger($config->isVerboseEnabled());
+  final public function run(ShipItManifest $manifest): void {
+    $logger = new ShipItVerboseLogger($manifest->isVerboseEnabled());
 
     if (
-      $this->isProjectSpecific() && !$config->areProjectSpecificPhasesEnabled()
+      $this->isProjectSpecific() && !$manifest->areProjectSpecificPhasesEnabled()
     ) {
       $this->skip();
     }
@@ -63,7 +63,7 @@ abstract class ShipItPhase {
     }
     $logger->out("Starting phase: %s", $this->getReadableName());
     try {
-      $this->runImpl($config);
+      $this->runImpl($manifest);
     } catch (ShipItExitException $e) {
       $logger->out("Finished phase: %s", $this->getReadableName());
       // This is used to signal that ShipIt is exiting, not a reportable

--- a/src/shipit/phase/ShipItPhaseRunner.php
+++ b/src/shipit/phase/ShipItPhaseRunner.php
@@ -18,7 +18,7 @@ class ShipItPhaseRunner {
   protected IShipItArgumentParser $argumentParser;
 
   public function __construct(
-    protected ShipItBaseConfig $config,
+    protected ShipItManifest $manifest,
     protected vec<ShipItPhase> $phases,
     ?IShipItArgumentParser $argumentParser = null,
   ) {
@@ -29,14 +29,14 @@ class ShipItPhaseRunner {
     $this->parseCLIArguments();
     try {
       foreach ($this->phases as $phase) {
-        $phase->run($this->config);
+        $phase->run($this->manifest);
       }
     } finally {
-      if ($this->config->hasSourceSharedLock()) {
-        $this->config->getSourceSharedLock()->release();
+      if ($this->manifest->hasSourceSharedLock()) {
+        $this->manifest->getSourceSharedLock()->release();
       }
-      if ($this->config->hasDestinationSharedLock()) {
-        $this->config->getDestinationSharedLock()->release();
+      if ($this->manifest->hasDestinationSharedLock()) {
+        $this->manifest->getDestinationSharedLock()->release();
       }
     }
   }
@@ -52,72 +52,72 @@ class ShipItPhaseRunner {
         'long_name' => 'base-dir::',
         'description' => 'Path to store repositories',
         'write' => $x ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withBaseDirectory(Str\trim($x));
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
         'long_name' => 'temp-dir::',
         'replacement' => 'base-dir',
         'write' => $x ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withBaseDirectory(Str\trim($x));
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
         'long_name' => 'source-repo-dir::',
         'description' => 'path to fetch source from',
         'write' => $x ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withSourcePath(Str\trim($x));
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
         'long_name' => 'destination-repo-dir::',
         'description' => 'path to push filtered changes to',
         'write' => $x ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withDestinationPath(Str\trim($x));
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
         'long_name' => 'source-branch::',
         'description' => "Branch to sync from",
         'write' => $x ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withSourceBranch(Str\trim($x));
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
         'long_name' => 'src-branch::',
         'replacement' => 'source-branch',
         'write' => $x ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withSourceBranch(Str\trim($x));
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
         'long_name' => 'destination-branch::',
         'description' => 'Branch to sync to',
         'write' => $x ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withDestinationBranch(Str\trim($x));
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
         'long_name' => 'dest-branch::',
         'replacement' => 'destination-branch',
         'write' => $x ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withDestinationBranch(Str\trim($x));
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
@@ -128,9 +128,9 @@ class ShipItPhaseRunner {
         'long_name' => 'skip-project-specific',
         'description' => 'Skip anything project-specific',
         'write' => $_ ==> {
-          $this->config = $this->config
+          $this->manifest = $this->manifest
             ->withProjectSpecificPhasesDisabled();
-          return $this->config;
+          return $this->manifest;
         },
       ),
       shape(
@@ -138,8 +138,8 @@ class ShipItPhaseRunner {
         'long_name' => 'verbose',
         'description' => 'Give more verbose output',
         'write' => $_ ==> {
-          $this->config = $this->config->withVerboseEnabled();
-          return $this->config;
+          $this->manifest = $this->manifest->withVerboseEnabled();
+          return $this->manifest;
         },
       ),
     ];

--- a/src/shipit/phase/ShipItPullPhase.php
+++ b/src/shipit/phase/ShipItPullPhase.php
@@ -53,17 +53,17 @@ final class ShipItPullPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  protected function runImpl(ShipItBaseConfig $config): void {
+  protected function runImpl(ShipItManifest $manifest): void {
     switch ($this->side) {
       case ShipItRepoSide::SOURCE:
-        $lock = $config->getSourceSharedLock();
-        $local_path = $config->getSourcePath();
-        $branch = $config->getSourceBranch();
+        $lock = $manifest->getSourceSharedLock();
+        $local_path = $manifest->getSourcePath();
+        $branch = $manifest->getSourceBranch();
         break;
       case ShipItRepoSide::DESTINATION:
-        $lock = $config->getDestinationSharedLock();
-        $local_path = $config->getDestinationPath();
-        $branch = $config->getDestinationBranch();
+        $lock = $manifest->getDestinationSharedLock();
+        $local_path = $manifest->getDestinationPath();
+        $branch = $manifest->getDestinationBranch();
         break;
     }
     ShipItRepo::open($lock, $local_path, $branch)->pull();

--- a/src/shipit/phase/ShipItPushLfsPhase.php
+++ b/src/shipit/phase/ShipItPushLfsPhase.php
@@ -48,17 +48,17 @@ final class ShipItPushLfsPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  final protected function runImpl(ShipItBaseConfig $config): void {
+  final protected function runImpl(ShipItManifest $manifest): void {
     switch ($this->side) {
       case ShipItRepoSide::SOURCE:
-        $lock = $config->getSourceSharedLock();
-        $local_path = $config->getSourcePath();
-        $branch = $config->getSourceBranch();
+        $lock = $manifest->getSourceSharedLock();
+        $local_path = $manifest->getSourcePath();
+        $branch = $manifest->getSourceBranch();
         break;
       case ShipItRepoSide::DESTINATION:
-        $lock = $config->getDestinationSharedLock();
-        $local_path = $config->getDestinationPath();
-        $branch = $config->getDestinationBranch();
+        $lock = $manifest->getDestinationSharedLock();
+        $local_path = $manifest->getDestinationPath();
+        $branch = $manifest->getDestinationBranch();
         break;
     }
     // FIXME LFS syncing only supported for internal->external

--- a/src/shipit/phase/ShipItPushPhase.php
+++ b/src/shipit/phase/ShipItPushPhase.php
@@ -35,16 +35,16 @@ final class ShipItPushPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  final protected function runImpl(ShipItBaseConfig $config): void {
+  final protected function runImpl(ShipItManifest $manifest): void {
     $repo = ShipItRepo::open(
-      $config->getDestinationSharedLock(),
-      $config->getDestinationPath(),
-      $config->getDestinationBranch(),
+      $manifest->getDestinationSharedLock(),
+      $manifest->getDestinationPath(),
+      $manifest->getDestinationBranch(),
     );
     invariant(
       $repo is ShipItDestinationRepo,
       '%s is not a writable repository type - got %s, needed %s',
-      $config->getDestinationPath(),
+      $manifest->getDestinationPath(),
       \get_class($repo),
       ShipItDestinationRepo::class,
     );

--- a/src/shipit/phase/ShipItSaveConfigPhase.php
+++ b/src/shipit/phase/ShipItSaveConfigPhase.php
@@ -57,28 +57,28 @@ final class ShipItSaveConfigPhase extends ShipItPhase {
     ];
   }
 
-  public function renderConfig(ShipItBaseConfig $config): self::TSavedConfig {
+  public function renderConfig(ShipItManifest $manifest): self::TSavedConfig {
     return shape(
       'destination' => shape(
-        'branch' => $config->getDestinationBranch(),
+        'branch' => $manifest->getDestinationBranch(),
         'owner' => $this->owner,
         'project' => $this->project,
       ),
       'source' => shape(
-        'branch' => $config->getSourceBranch(),
-        'roots' => $config->getSourceRoots(),
+        'branch' => $manifest->getSourceBranch(),
+        'roots' => $manifest->getSourceRoots(),
       ),
     );
   }
 
   <<__Override>>
-  protected function runImpl(ShipItBaseConfig $config): void {
+  protected function runImpl(ShipItManifest $manifest): void {
     invariant($this->outputFile !== null, 'impossible');
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     \file_put_contents(
       $this->outputFile,
-      \json_encode($this->renderConfig($config), \JSON_PRETTY_PRINT),
+      \json_encode($this->renderConfig($manifest), \JSON_PRETTY_PRINT),
     );
     ShipItLogger::out("Finished phase: %s\n", $this->getReadableName());
     throw new ShipItExitException(0);

--- a/src/shipit/phase/ShipItSyncPhase.php
+++ b/src/shipit/phase/ShipItSyncPhase.php
@@ -114,10 +114,10 @@ final class ShipItSyncPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  protected function runImpl(ShipItBaseConfig $base): void {
+  protected function runImpl(ShipItManifest $manifest): void {
     $sync = (
       new ShipItSyncConfig(
-        $base->getSourceRoots(),
+        $manifest->getSourceRoots(),
         $this->filter,
         $this->postFilterChangesets,
       )
@@ -130,6 +130,6 @@ final class ShipItSyncPhase extends ShipItPhase {
       ->withAllowEmptyCommits($this->allowEmptyCommit)
       ->withShouldDoSubmodules($this->shouldDoSubmodules);
 
-    (new ShipItSync($base, $sync))->run();
+    (new ShipItSync($manifest, $sync))->run();
   }
 }

--- a/src/shipit/phase/ShipItVerifyRepoPhase.php
+++ b/src/shipit/phase/ShipItVerifyRepoPhase.php
@@ -84,7 +84,7 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
   }
 
   <<__Override>>
-  public function runImpl(ShipItBaseConfig $config): void {
+  public function runImpl(ShipItManifest $manifest): void {
     if ($this->useLatestSourceCommit) {
       if ($this->verifySourceCommit !== null) {
         throw new ShipItException(
@@ -95,14 +95,14 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
       }
       $repo = ShipItRepo::typedOpen(
         ShipItDestinationRepo::class,
-        $config->getDestinationSharedLock(),
-        $config->getDestinationPath(),
-        $config->getDestinationBranch(),
+        $manifest->getDestinationSharedLock(),
+        $manifest->getDestinationPath(),
+        $manifest->getDestinationBranch(),
       );
       $this->verifySourceCommit = $repo->findLastSourceCommit(keyset[]);
     }
     $clean_dir = ShipItCreateNewRepoPhase::createNewGitRepo(
-      $config,
+      $manifest,
       $this->filter,
       shape(
         'name' => 'FBShipIt Internal User',
@@ -113,7 +113,7 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
     );
     $clean_path = $clean_dir->getPath();
     $dirty_remote = 'shipit_dest';
-    $dirty_ref = $dirty_remote.'/'.$config->getDestinationBranch();
+    $dirty_ref = $dirty_remote.'/'.$manifest->getDestinationBranch();
 
     (
       new ShipItShellCommand(
@@ -122,7 +122,7 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
         'remote',
         'add',
         $dirty_remote,
-        $config->getDestinationPath(),
+        $manifest->getDestinationPath(),
       )
     )->runSynchronously();
     (
@@ -176,9 +176,9 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
     if ($source_sync_id === null) {
       $repo = ShipItRepo::typedOpen(
         ShipItSourceRepo::class,
-        $config->getSourceSharedLock(),
-        $config->getSourcePath(),
-        $config->getSourceBranch(),
+        $manifest->getSourceSharedLock(),
+        $manifest->getSourcePath(),
+        $manifest->getSourceBranch(),
       );
       $changeset = $repo->getHeadChangeset();
       if ($changeset === null) {
@@ -213,7 +213,7 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
       "  the changes carefully.\n\n",
       $patch_file,
       $diffstat,
-      $config->getDestinationPath(),
+      $manifest->getDestinationPath(),
       $patch_file,
       $source_sync_id,
     );

--- a/tests/importit/SubmoduleTest.php
+++ b/tests/importit/SubmoduleTest.php
@@ -172,7 +172,7 @@ final class SubmoduleTest extends \Facebook\ShipIt\ShellTest {
     self::configureGit($source_dir);
     $source_dir = \Facebook\ShipIt\ShipItCreateNewRepoPhase::createNewGitRepo(
       (
-        new \Facebook\ShipIt\ShipItBaseConfig(
+        new \Facebook\ShipIt\ShipItManifest(
           '',
           $dest_dir->getPath(),
           //$source_dir->getPath(),

--- a/tests/shipit/SyncTrackingTest.php
+++ b/tests/shipit/SyncTrackingTest.php
@@ -50,8 +50,8 @@ final class SyncTrackingTest extends ShellTest {
     $this->tempDir?->remove();
   }
 
-  private function getBaseConfig(): ShipItBaseConfig {
-    return (new ShipItBaseConfig('/var/tmp/fbshipit', '', '', keyset[]))
+  private function getManifest(): ShipItManifest {
+    return (new ShipItManifest('/var/tmp/fbshipit', '', '', keyset[]))
       ->withCommitMarkerPrefix(true);
   }
 
@@ -77,7 +77,7 @@ final class SyncTrackingTest extends ShellTest {
     /* HH_FIXME[4107] __PHPStdLib */
     $fake_commit_id = \bin2hex(\random_bytes(16));
     $message = ShipItSync::addTrackingData(
-      $this->getBaseConfig(),
+      $this->getManifest(),
       (new ShipItChangeset())->withID($fake_commit_id),
     )->getMessage();
     \expect($message)->toContainSubstring('fbshipit');
@@ -98,7 +98,7 @@ final class SyncTrackingTest extends ShellTest {
     /* HH_FIXME[4107] __PHPStdLib */
     $fake_commit_id = \bin2hex(\random_bytes(16));
     $message = ShipItSync::addTrackingData(
-      $this->getBaseConfig(),
+      $this->getManifest(),
       (new ShipItChangeset())->withID($fake_commit_id),
     )->getMessage();
     (new ShipItShellCommand($path, 'touch', 'testfile'))->runSynchronously();
@@ -118,11 +118,11 @@ final class SyncTrackingTest extends ShellTest {
     /* HH_FIXME[4107] __PHPStdLib */
     $fake_commit_id_2 = \bin2hex(\random_bytes(16));
     $message_1 = ShipItSync::addTrackingData(
-      $this->getBaseConfig(),
+      $this->getManifest(),
       (new ShipItChangeset())->withID($fake_commit_id_1),
     )->getMessage();
     $message_2 = ShipItSync::addTrackingData(
-      $this->getBaseConfig(),
+      $this->getManifest(),
       (new ShipItChangeset())->withID($fake_commit_id_2),
     )->getMessage();
     $repo = $this->getGITRepoWithCommit($message_1."\n\n".$message_2);
@@ -134,7 +134,7 @@ final class SyncTrackingTest extends ShellTest {
     /* HH_FIXME[4107] __PHPStdLib */
     $fake_commit_id = \bin2hex(\random_bytes(16));
     $message = ShipItSync::addTrackingData(
-      $this->getBaseConfig(),
+      $this->getManifest(),
       (new ShipItChangeset())->withID($fake_commit_id),
     )->getMessage();
     $repo = $this->getGITRepoWithCommit($message." ");
@@ -155,7 +155,7 @@ final class SyncTrackingTest extends ShellTest {
     /* HH_FIXME[4107] __PHPStdLib */
     $fake_commit_id = \bin2hex(\random_bytes(16));
     $message = ShipItSync::addTrackingData(
-      $this->getBaseConfig()->withCommitMarkerPrefix(false),
+      $this->getManifest()->withCommitMarkerPrefix(false),
       (new ShipItChangeset())->withID($fake_commit_id),
     )->getMessage();
     \expect($message)->toNotContainSubstring('fbshipit');
@@ -167,7 +167,7 @@ final class SyncTrackingTest extends ShellTest {
     $in = (new ShipItChangeset())
       ->withCoAuthorLines("Co-authored-by: Jon Janzen <jonjanzen@fb.com>");
     $out = ShipItSync::addTrackingData(
-      $this->getBaseConfig()->withCommitMarkerPrefix(true),
+      $this->getManifest()->withCommitMarkerPrefix(true),
       $in,
       "TEST",
     );


### PR DESCRIPTION
Summary:
And all the variables names too.

We have too many configs in ShipIt:
1. FBShipItConfig
2. FBSourceBranchConfig
3. FBShipItCLIStaticConfig
4. ShipItBaseConfig

This is endlessly confusing for newcomers. "Manifest" means the same thing but it is visually and semantically distinct. I plan on renaming `FBSourceBranchConfig` as soon as I can think of a good name. And `FBShipItCLIStaticConfig` should just be normal fields on the config.

Reviewed By: jurajh-fb

Differential Revision: D23588313

