### PR TITLE
Update GitHub Actions environment syntax

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -9,7 +9,7 @@ apt-get install -y \
   locales
 
 locale-gen en_US.UTF-8
-echo "::set-env name=LC_ALL::en_US.UTF-8"
+echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
 
 git --version
 hg --version


### PR DESCRIPTION
Ref:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

Test plan:
CI on the PR