### PR TITLE
Allow fully custom commit markers

### DIFF
--- a/src/importit/phase/ImportItSyncPhase.php
+++ b/src/importit/phase/ImportItSyncPhase.php
@@ -163,6 +163,7 @@ final class ImportItSyncPhase extends \Facebook\ShipIt\ShipItPhase {
       $expected_head_rev,
       $manifest->getSourceBranch(),
       $this->applyToLatest,
+      $manifest->getCommitMarker(),
     );
   }
 

--- a/src/importit/repo/ImportItRepoGIT.php
+++ b/src/importit/repo/ImportItRepoGIT.php
@@ -31,6 +31,7 @@ final class ImportItRepoGIT extends \Facebook\ShipIt\ShipItRepoGIT {
     string $expected_head_rev,
     string $source_default_branch,
     bool $use_latest_base_revision,
+    string $commit_marker,
   ): Awaitable<(ShipItChangeset, ?string)> {
     using $this->getSharedLock()->getExclusive();
     return await $this->genChangesetAndBaseRevisionForPullRequestLocked(
@@ -38,6 +39,7 @@ final class ImportItRepoGIT extends \Facebook\ShipIt\ShipItRepoGIT {
       $expected_head_rev,
       $source_default_branch,
       $use_latest_base_revision,
+      $commit_marker,
     );
   }
 
@@ -46,6 +48,7 @@ final class ImportItRepoGIT extends \Facebook\ShipIt\ShipItRepoGIT {
     string $expected_head_rev,
     string $source_default_branch,
     bool $use_latest_base_revision,
+    string $commit_marker,
   ): Awaitable<(ShipItChangeset, ?string)> {
     if ($pr_number === null) {
       $actual_head_rev =
@@ -123,7 +126,8 @@ final class ImportItRepoGIT extends \Facebook\ShipIt\ShipItRepoGIT {
     if ($use_latest_base_revision) {
       $base_revision = null;
     } else {
-      $base_revision = await $this->genFindLastSourceCommit(keyset[]);
+      $base_revision =
+        await $this->genFindLastSourceCommit(keyset[], $commit_marker);
     }
     return tuple($changeset, $base_revision);
   }

--- a/src/shipit/ShipItManifest.php
+++ b/src/shipit/ShipItManifest.php
@@ -21,7 +21,7 @@ final class ShipItManifest {
     private string $defaultSourceDirectoryName,
     private string $defaultDestinationDirectoryName,
     private keyset<string> $sourceRoots,
-    private bool $commitMarkerPrefix = false,
+    private string $commitMarker = 'fbshipit-source-id',
   ) {}
 
   public function getBaseDirectory(): string {
@@ -123,14 +123,14 @@ final class ShipItManifest {
     );
   }
 
-  public function getCommitMarkerPrefix(): bool {
-    return $this->commitMarkerPrefix;
+  public function getCommitMarker(): string {
+    return $this->commitMarker;
   }
 
-  public function withCommitMarkerPrefix(bool $bool): this {
+  public function withCommitMarker(string $marker): this {
     return $this->modified($ret ==> {
-      $ret->commitMarkerPrefix = $bool;
-      return $ret->commitMarkerPrefix;
+      $ret->commitMarker = $marker;
+      return $ret->commitMarker;
     });
   }
 

--- a/src/shipit/phase/ShipItVerifyRepoPhase.php
+++ b/src/shipit/phase/ShipItVerifyRepoPhase.php
@@ -95,8 +95,10 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
         $manifest->getDestinationPath(),
         $manifest->getDestinationBranch(),
       );
-      $this->verifySourceCommit =
-        await $repo->genFindLastSourceCommit(keyset[]);
+      $this->verifySourceCommit = await $repo->genFindLastSourceCommit(
+        keyset[],
+        $manifest->getCommitMarker(),
+      );
     }
     $clean_dir = await ShipItCreateNewRepoPhase::genCreateNewGitRepo(
       $manifest,
@@ -199,7 +201,7 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
       "    $ git apply < %s\n".
       "    $ git status\n".
       "    $ git add --all --patch\n".
-      "    $ git commit -m 'fbshipit-source-id: %s'\n".
+      "    $ git commit -m '%s: %s'\n".
       "    $ git push\n\n".
       "  WARNING: there are 4 possible causes for differences:\n\n".
       "    1. changes in source haven't been copied to destination\n".
@@ -212,6 +214,7 @@ final class ShipItVerifyRepoPhase extends ShipItPhase {
       $diffstat,
       $manifest->getDestinationPath(),
       $patch_file,
+      $manifest->getCommitMarker(),
       $source_sync_id,
     );
     throw new ShipItExitException(0);

--- a/src/shipit/repo/ShipItDestinationRepo.php
+++ b/src/shipit/repo/ShipItDestinationRepo.php
@@ -17,12 +17,14 @@ interface ShipItDestinationRepo {
   require extends ShipItRepo;
 
   /**
-   * Find the contents of the fbshipit-source-id: header in the latest commit.
+   * Find the contents of the specified commit marker in the latest commit.
    *
    * @param $roots list of paths that contain synced commits.
+   * @param $commit_marker normally, fbshipit-source-id, but can be customized.
    */
   public function genFindLastSourceCommit(
     keyset<string> $roots,
+    string $commit_marker,
   ): Awaitable<?string>;
 
   /**

--- a/src/shipit/repo/ShipItRepoGIT.php
+++ b/src/shipit/repo/ShipItRepoGIT.php
@@ -67,16 +67,17 @@ class ShipItRepoGIT
 
   public async function genFindLastSourceCommit(
     keyset<string> $roots,
+    string $commit_marker,
   ): Awaitable<?string> {
     $log = await $this->genGitCommand(
       'log',
       '-1',
       '--grep',
-      '^\\(fb\\)\\?shipit-source-id: \\?[a-z0-9]\\+\\s*$',
+      Str\format('^%s: \\?[a-z0-9]\\+\\s*$', $commit_marker),
       ...$roots
     );
     $log = Str\trim($log);
-    return ShipItSync::getTrackingDataFromString($log);
+    return ShipItSync::getTrackingDataFromString($log, $commit_marker);
   }
 
   public async function genFindNextCommit(

--- a/src/shipit/repo/ShipItRepoHG.php
+++ b/src/shipit/repo/ShipItRepoHG.php
@@ -114,19 +114,20 @@ class ShipItRepoHG
 
   public async function genFindLastSourceCommit(
     keyset<string> $roots,
+    string $commit_marker,
   ): Awaitable<?string> {
     $log = await $this->genHgCommand(
       'log',
       '--limit',
       '1',
       '--keyword',
-      'shipit-source-id:',
+      Str\format('%s:', $commit_marker),
       '--template',
       '{desc}',
       ...$roots
     );
     $log = Str\trim($log);
-    return ShipItSync::getTrackingDataFromString($log);
+    return ShipItSync::getTrackingDataFromString($log, $commit_marker);
   }
 
   public async function genCommitPatch(


### PR DESCRIPTION
Summary: This feature will be required for an internal project. We already have support for partially-custom commit markers, this just evolves that support.

Differential Revision: D32152069

