### PR TITLE
Use full git SHAs

### DIFF
--- a/src/shipit/repo/ShipItRepoGIT.php
+++ b/src/shipit/repo/ShipItRepoGIT.php
@@ -89,17 +89,15 @@ class ShipItRepoGIT
       $revision.'..',
       '--ancestry-path',
       '--no-merges',
-      '--oneline',
+      '--format=%H',
       ...$roots
     );
 
     $log = Str\trim($log);
-    if (Str\trim($log) === '') {
+    if ($log === '') {
       return null;
     }
-    $revs = Str\split(Str\trim($log), "\n");
-    list($rev) = Str\split(C\lastx($revs), ' ', 2);
-    return $rev;
+    return Str\split($log, "\n") |> C\lastx($$);
   }
 
   private static function parseHeader(string $header): ShipItChangeset {


### PR DESCRIPTION
Summary: Right now mercurial SHAs are always full-length, but git shas are repo-dependent when used as a ShipIt source. `git log --oneline` picks the length of the SHA it renders by the number of commits. This is nice for readability/users but a headache for automation that attempts to look for the tracking SHAs that ShipIt produces

Differential Revision: D34693603

