### PR TITLE
Invert heirarchy of ShipItRepo

### DIFF
--- a/src/importit/repo/ImportItRepo.php
+++ b/src/importit/repo/ImportItRepo.php
@@ -34,7 +34,7 @@ abstract class ImportItRepo {
     \Facebook\ShipIt\IShipItLock $lock,
     string $path,
     string $branch,
-  ): Awaitable<\Facebook\ShipIt\ShipItRepo> {
+  ): Awaitable<\Facebook\ShipIt\IShipItRepo> {
     if (PHP\file_exists($path.'/.git')) {
       $repo = new ImportItRepoGIT($lock, $path);
       await $repo->genSetBranch($branch);

--- a/src/shipit/ShipItSync.php
+++ b/src/shipit/ShipItSync.php
@@ -277,7 +277,7 @@ final class ShipItSync {
   }
 
   <<__Memoize>>
-  private async function genRepo<<<__Enforceable>> reify Trepo as ShipItRepo>(
+  private async function genRepo<<<__Enforceable>> reify Trepo as IShipItRepo>(
   ): Awaitable<Trepo> {
     $manifest = $this->manifest;
 

--- a/src/shipit/ShipItSyncConfig.php
+++ b/src/shipit/ShipItSyncConfig.php
@@ -20,7 +20,7 @@ final class ShipItSyncConfig {
   ): Awaitable<ShipItChangeset>);
   const type TPostFilterChangesetsFn = (function(
     vec<ShipItChangeset>,
-    ShipItRepo,
+    IShipItRepo,
   ): Awaitable<vec<ShipItChangeset>>);
   const type TStatsFn = (function(
     vec<ShipItChangeset>,
@@ -110,7 +110,7 @@ final class ShipItSyncConfig {
 
   public async function genPostFilterChangesets(
     vec<ShipItChangeset> $changesets,
-    ShipItRepo $dest,
+    IShipItRepo $dest,
   ): Awaitable<vec<ShipItChangeset>> {
     $post_filter_changesets = $this->postFilterChangesets;
     if ($post_filter_changesets === null) {

--- a/src/shipit/repo/IShipItRepo.php
+++ b/src/shipit/repo/IShipItRepo.php
@@ -1,0 +1,67 @@
+<?hh
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+namespace Facebook\ShipIt;
+
+interface IShipItRepo {
+  protected function getSharedLock(): IShipItLock;
+
+  public function getPath(): string;
+
+  public static function genTypedOpen<
+    <<__Enforceable>> reify Trepo as IShipItRepo,
+  >(IShipItLock $lock, string $path, string $branch): Awaitable<Trepo>;
+
+  /**
+   * Factory
+   */
+  public static function genOpen(
+    IShipItLock $lock,
+    string $path,
+    string $branch,
+  ): Awaitable<IShipItRepo>;
+
+  public static function parseDiffHunk(string $hunk): ?ShipItDiff;
+
+  public static function getCommitMessage(ShipItChangeset $changeset): string;
+
+  public static function parsePatch(string $patch): Iterator<string>;
+
+  /**
+   * Implement to allow changing branches
+   */
+  protected function genSetBranch(string $branch): Awaitable<bool>;
+
+  public function genUpdateBranchTo(string $base_rev): Awaitable<void>;
+
+  /**
+   * Cleans our checkout.
+   */
+  public function genClean(): Awaitable<void>;
+
+  /**
+   * Updates our checkout
+   */
+  public function genPull(): Awaitable<void>;
+
+  /**
+   * push lfs support
+   */
+  public function genPushLfs(
+    string $lfs_pull_endpoint,
+    string $lfs_push_endpoint,
+  ): Awaitable<void>;
+
+  /**
+   * Get the origin of the checkout.
+   */
+  public function genOrigin(): Awaitable<string>;
+
+  /**
+   * Get the ShipItChangeset of the HEAD revision in the current branch.
+   */
+  public function genHeadChangeset(): Awaitable<?ShipItChangeset>;
+
+  public static function getDiffsFromPatch(string $patch): vec<ShipItDiff>;
+
+}

--- a/src/shipit/repo/ShipItDestinationRepo.php
+++ b/src/shipit/repo/ShipItDestinationRepo.php
@@ -13,8 +13,7 @@
  */
 namespace Facebook\ShipIt;
 
-interface ShipItDestinationRepo {
-  require extends ShipItRepo;
+interface ShipItDestinationRepo extends IShipItRepo {
 
   /**
    * Find the contents of the specified commit marker in the latest commit.

--- a/src/shipit/repo/ShipItRepoGIT.php
+++ b/src/shipit/repo/ShipItRepoGIT.php
@@ -20,9 +20,7 @@ final class ShipItRepoGITException extends ShipItRepoException {}
 /**
  * GIT specialization of ShipItRepo
  */
-class ShipItRepoGIT
-  extends ShipItRepo
-  implements ShipItSourceRepo, ShipItDestinationRepo {
+class ShipItRepoGIT extends ShipItRepo {
 
   const type TSubmoduleSpec = shape(
     'name' => string,

--- a/src/shipit/repo/ShipItRepoHG.php
+++ b/src/shipit/repo/ShipItRepoHG.php
@@ -20,9 +20,7 @@ final class ShipItRepoHGException extends ShipItRepoException {}
 /**
  * HG specialization of ShipItRepo
  */
-class ShipItRepoHG
-  extends ShipItRepo
-  implements ShipItDestinationRepo, ShipItSourceRepo {
+class ShipItRepoHG extends ShipItRepo {
   private ?string $branch;
   const string COMMIT_SEPARATOR = '-~-~-~';
 

--- a/src/shipit/repo/ShipItSourceRepo.php
+++ b/src/shipit/repo/ShipItSourceRepo.php
@@ -13,8 +13,7 @@
  */
 namespace Facebook\ShipIt;
 
-interface ShipItSourceRepo {
-  require extends ShipItRepo;
+interface ShipItSourceRepo extends IShipItRepo {
   /**
    * Get the next child of this revision in the current branch.
    *

--- a/tests/shipit/FakeShipItRepo.php
+++ b/tests/shipit/FakeShipItRepo.php
@@ -54,4 +54,65 @@ final class FakeShipItRepo extends ShipItRepo {
   public static function getDiffsFromPatch(string $_patch): vec<ShipItDiff> {
     return vec[];
   }
+
+  public static function renderPatch(ShipItChangeset $patch): string {
+    return '';
+  }
+
+  public static function getChangesetFromExportedPatch(
+    string $header,
+    string $patch,
+  ): ShipItChangeset {
+    return new ShipItChangeset();
+  }
+
+  public async function genPush(): Awaitable<void> {
+  }
+
+  public async function genNativePatchFromID(
+    string $revision,
+  ): Awaitable<string> {
+    return '';
+  }
+  public async function genNativeHeaderFromID(
+    string $revision,
+  ): Awaitable<string> {
+    return '';
+  }
+
+  public async function genFindNextCommit(
+    string $revision,
+    keyset<string> $roots,
+  ): Awaitable<?string> {
+    return null;
+  }
+
+  public async function genFindLastSourceCommit(
+    keyset<string> $roots,
+    string $commit_marker,
+  ): Awaitable<?string> {
+    return null;
+  }
+
+  public async function genExport(
+    keyset<string> $roots,
+    bool $do_submodules,
+    ?string $rev = null,
+  ): Awaitable<shape('tempDir' => ShipItTempDir, 'revision' => string)> {
+    return shape('tempDir' => new ShipItTempDir(''), 'revision' => '');
+  }
+
+  public async function genCommitPatch(
+    ShipItChangeset $patch,
+    bool $do_submodules = true,
+  ): Awaitable<string> {
+    return '';
+  }
+
+  public async function genChangesetFromID(
+    string $revision,
+  ): Awaitable<ShipItChangeset> {
+    return new ShipItChangeset();
+  }
+
 }


### PR DESCRIPTION
Summary:
before:
ShipItRepo -> (ShipItSourceRepo & ShipItDestinationRepo) -> (ShipItRepoHG | ShipItRepoGIT)

after:
IShipItRepo -> (ShipItSourceRepo & ShipItDestinationRepo) -> ShipItRepo -> (ShipItRepoHG | ShipItRepoGIT)

Plus the dummy repo, who cares about that one though.

This makes the next diff much more pleasant

Reviewed By: wittgenst

Differential Revision: D34979244

