### PR TITLE
Add new option to sync from a specific rev

### DIFF
--- a/src/shipit/ShipItSync.php
+++ b/src/shipit/ShipItSync.php
@@ -120,6 +120,11 @@ final class ShipItSync {
     $verbose = $this->manifest->isVerboseEnabled();
     $dest = await $this->genRepo<ShipItDestinationRepo>();
 
+    $start_sync_at_rev = $this->syncConfig->getStartSyncAtRev();
+    if ($start_sync_at_rev is nonnull) {
+      await $dest->genUpdateBranchTo($start_sync_at_rev);
+    }
+
     $changesets = await $this->syncConfig
       ->genPostFilterChangesets($changesets, $dest);
 

--- a/src/shipit/ShipItSyncConfig.php
+++ b/src/shipit/ShipItSyncConfig.php
@@ -35,6 +35,7 @@ final class ShipItSyncConfig {
   private ?self::TStatsFn $statsFunction = null;
   private ?bool $allowEmptyCommit = false;
   private bool $doSubmodules = true;
+  private ?string $startSyncAtRev = null;
 
   public function __construct(
     private keyset<string> $sourceRoots,
@@ -169,6 +170,17 @@ final class ShipItSyncConfig {
 
   public function getShouldDoSubmodules(): bool {
     return $this->doSubmodules;
+  }
+
+  public function withStartSyncAtRev(?string $rev): this {
+    return $this->modified($ret ==> {
+      $ret->startSyncAtRev = $rev;
+      return $ret->startSyncAtRev;
+    });
+  }
+
+  public function getStartSyncAtRev(): ?string {
+    return $this->startSyncAtRev;
   }
 
   private function modified<Tignored>(

--- a/src/shipit/phase/ShipItSyncPhase.php
+++ b/src/shipit/phase/ShipItSyncPhase.php
@@ -21,6 +21,7 @@ final class ShipItSyncPhase extends ShipItPhase {
   private ?string $patchesDirectory = null;
   private ?string $statsFilename = null;
   private bool $shouldDoSubmodules = true;
+  private ?string $startSyncAtRev = null;
 
   public function __construct(
     private ShipItSyncConfig::TFilterFn $filter,
@@ -107,6 +108,15 @@ final class ShipItSyncPhase extends ShipItPhase {
           return $this->shouldDoSubmodules;
         },
       ),
+      shape(
+        'long_name' => 'start-sync-at::',
+        'description' =>
+          'Commit ID in the destination repo to set HEAD to before syncing',
+        'write' => $x ==> {
+          $this->startSyncAtRev = $x;
+          return $this->startSyncAtRev;
+        },
+      ),
     ];
   }
 
@@ -128,7 +138,8 @@ final class ShipItSyncPhase extends ShipItPhase {
       ->withStatsFilename($this->statsFilename)
       ->withStatsFunction($this->statsFunction)
       ->withAllowEmptyCommits($this->allowEmptyCommit)
-      ->withShouldDoSubmodules($this->shouldDoSubmodules);
+      ->withShouldDoSubmodules($this->shouldDoSubmodules)
+      ->withStartSyncAtRev($this->startSyncAtRev);
 
     await (new ShipItSync($manifest, $sync))->genRun();
   }


### PR DESCRIPTION
Summary:
Obviously this is a bad idea for committing then pushing, but this is useful when "syncing" a Phabricator Diff with ShipIt in order to create a Pull Request.

A later step in the export process will create a new branch and push that to a fork, we just need to unwind the base branch back to the commit we want to export.

A later diff will make the necessary changes to the export job to translate revisions from Meta internal to GitHub, then set this option appropriately.

Differential Revision: D35943443

