### PR TITLE
Allow empty commits when attempting to squash

### DIFF
--- a/src/shipit/phase/ShipItCreateNewRepoPhase.php
+++ b/src/shipit/phase/ShipItCreateNewRepoPhase.php
@@ -354,7 +354,7 @@ final class ShipItCreateNewRepoPhase extends ShipItPhase {
           vec['git', 'reset', '--soft', $initial_commit_sha],
           // Amend initial commit with content from all chunks
           // (this preserves initial commit's message w/ ShipIt tracking details)
-          vec['git', 'commit', '--amend', '--no-edit'],
+          vec['git', 'commit', '--amend', '--no-edit', '--allow-empty'],
         ],
       );
     } finally {


### PR DESCRIPTION
Summary:
To resolve problems seen in https://www.internalfb.com/intern/sandcastle/job/4503600300850538/insights

```
[Thu, 19 May 2022 21:58:58] [21:58:58] Finished phase WITH EXCEPTION: Verify that destination repository is sync
[Thu, 19 May 2022 21:58:58] Step "Verify synchronicity with ShipIt" failed with: Facebook\ShipIt\ShipItShellCommandException: 'git' 'commit' '--amend' '--no-edit' returned exit code 1: You asked to amend the most recent commit, but doing so would make
it empty. You can repeat your command with --allow-empty, or you can
remove the commit entirely with "git reset HEAD^".
[Thu, 19 May 2022 21:58:59] Detected infrastructure failure, terminating job
```

Allowing an empty commit should be fine right?

Differential Revision: D36538508

