### PR TITLE
Remove runtime-disabled code for git-style patch headers in HG repos

### DIFF
--- a/fb-examples/lib/shipit/FBShipItBranchResolutionPhase.php-example
+++ b/fb-examples/lib/shipit/FBShipItBranchResolutionPhase.php-example
@@ -131,8 +131,6 @@ class FBShipItBranchResolutionPhase extends ShipItPhase {
     $config_object = $this->configObject;
     $branch_configs = await $this->genBranchConfigs();
 
-    FBShipItScripts::disableHGNativeRenderingForPatchesIfNeeded();
-
     foreach ($branch_configs as $branch_config) {
       ShipItLogger::out(
         "--- Running for branch: (%s, %s)\n",

--- a/tests/shipit/ShipItRepoHGTest.php
+++ b/tests/shipit/ShipItRepoHGTest.php
@@ -31,24 +31,6 @@ change - change
 
 HGPATCH;
 
-  private static string $expectedGitPatch = <<< 'GITPATCH'
-From 730c1a3381881be0fc32d0b229e1b57ad4c3cb23 Mon Sep 17 00:00:00 2001
-From: Tester McTesterson <tester@example.com>
-Date: Mon, 20 Jun 2022 13:00:05 -0700
-Subject: [PATCH] From subject, I provide a tricky message, D1234567890
-
-From this place, I provide a tricky message, D1234567890
----
-
-diff --git a/sample/file/1 b/sample/file/1
-change - change
-diff --git a/sample/file/2 b/sample/file/2
-change - change
---
-1.7.9.5
-
-GITPATCH;
-
   <<__Override>>
   public static async function createData(): Awaitable<void> {
     date_default_timezone_set("America/Los_Angeles"); // @oss-enable
@@ -70,9 +52,8 @@ GITPATCH;
       ->withTimestamp(1655755205);
   }
 
-  public async function testRenderPatchNoEnvVariableToGenerateHgStyleHeader(
+  public async function testRenderPatchToGenerateHgStyleHeader(
   ): Awaitable<void> {
-
     $patch_output = ShipItRepoHG::renderPatch(self::$testChangeset);
 
     expect($patch_output)->toNotBeNull();
@@ -82,60 +63,5 @@ GITPATCH;
       self::$expectedHgPatch,
       "Failed to generate an HG styled header in the patch",
     );
-
-  }
-
-  public async function testRenderPatchSetButNotFalseEnvVariableToGenerateGitStyleHeader(
-  ): Awaitable<void> {
-    ShipItEnv::setEnv(
-      ShipItRepoHG::SHIPIT_DISABLE_HG_NATIVE_PATCH_RENDERING_ENV_KEY,
-      "nottrue",
-    );
-
-    $patch_output = ShipItRepoHG::renderPatch(self::$testChangeset);
-
-    expect($patch_output)->toNotBeNull();
-
-    // Verify we have a git styled header
-    expect($patch_output)->toEqual(
-      self::$expectedGitPatch,
-      "Failed to generate a git styled header in the patch",
-    );
-  }
-
-  public async function testRenderPatchTrueEnvVariableToGenerateGitStyleHeader(
-  ): Awaitable<void> {
-    ShipItEnv::setEnv(
-      ShipItRepoHG::SHIPIT_DISABLE_HG_NATIVE_PATCH_RENDERING_ENV_KEY,
-      "true",
-    );
-
-    $patch_output = ShipItRepoHG::renderPatch(self::$testChangeset);
-
-    expect($patch_output)->toNotBeNull();
-
-    // Verify we have a git styled header
-    expect($patch_output)->toEqual(
-      self::$expectedGitPatch,
-      "Failed to generate a git styled header in the patch",
-    );
-  }
-
-  public async function testRenderPatchFalseEnvVariableToGenerateHgStyleHeader(
-  ): Awaitable<void> {
-    ShipItEnv::setEnv(
-      ShipItRepoHG::SHIPIT_DISABLE_HG_NATIVE_PATCH_RENDERING_ENV_KEY,
-      "false",
-    );
-
-    $patch_output = ShipItRepoHG::renderPatch(self::$testChangeset);
-
-    expect($patch_output)->toNotBeNull();
-    // Verify we have an HG styled header
-    expect($patch_output)->toEqual(
-      self::$expectedHgPatch,
-      "Failed to generate an HG styled header in the patch",
-    );
-
   }
 }


### PR DESCRIPTION
Summary:
CC apiri

This has been stable for months, I see no reason to keep this extra complexity around.

Reviewed By: jailby

Differential Revision: D40104929

